### PR TITLE
[FD-37] feat: 수시 피드백 전송

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/event/EventPublisher.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/event/EventPublisher.java
@@ -1,0 +1,6 @@
+package com.feedhanjum.back_end.event;
+
+public interface EventPublisher {
+
+    void publishEvent(Object event);
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/event/SpringEventPublisherImpl.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/event/SpringEventPublisherImpl.java
@@ -1,0 +1,18 @@
+package com.feedhanjum.back_end.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringEventPublisherImpl implements EventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public SpringEventPublisherImpl(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    @Override
+    public void publishEvent(Object event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
@@ -4,24 +4,32 @@ import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.team.domain.Team;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Feedback {
+    private static final int MIN_OBJECTIVE_FEEDBACK_SIZE = 1;
+    private static final int MAX_OBJECTIVE_FEEDBACK_SIZE = 5;
+    // 객관식 피드백
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "objective_feedback", joinColumns = @JoinColumn(name = "feedback_id"))
+    private final Set<ObjectiveFeedback> objectiveFeedbacks = new HashSet<>();
     @Id
     @Column(name = "feedback_id")
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
-
     @Enumerated(EnumType.STRING)
     private FeedbackType feedbackType;
-
-    // 객관식 피드백
-    // private ObjectiveFeedback objectiveFeedback
-
+    @Enumerated(EnumType.STRING)
+    private FeedbackCategory feedbackCategory;
     private String subjectiveFeedback;
 
     private boolean liked = false;
@@ -38,33 +46,55 @@ public class Feedback {
     @JoinColumn(name = "team_id")
     private Team team;
 
-    public Feedback(FeedbackType feedbackType, String subjectiveFeedback, Member sender, Member receiver, Team team) {
+    /**
+     * @throws IllegalArgumentException 객관식 피드백이 보기에 없거나, 피드백 카테고리에 맞지 않는 값이 있을 경우, 또는 객관식 피드백이 1개 이상 5개 이하가 아닐 경우
+     */
+    @Builder
+    public Feedback(FeedbackType feedbackType, FeedbackCategory feedbackCategory, List<String> objectiveFeedbacks, String subjectiveFeedback, Member sender, Member receiver, Team team) {
         this.feedbackType = feedbackType;
         this.subjectiveFeedback = subjectiveFeedback;
+        this.feedbackCategory = feedbackCategory;
+        for (String objectiveFeedback : objectiveFeedbacks) {
+            this.objectiveFeedbacks.add(ObjectiveFeedback.from(objectiveFeedback)
+                    .orElseThrow(() -> new IllegalArgumentException("허용되지 않는 객관식 피드백 값입니다:" + objectiveFeedback)));
+        }
         this.sender = sender;
         this.team = team;
+        validateObjectiveFeedbacksCategory();
         setReceiver(receiver);
     }
 
-    private void setReceiver(Member receiver) {
-        if(this.receiver != null) {
-            this.receiver.getFeedbacks().remove(this);
-        }
-        this.receiver = receiver;
-        if(receiver != null && !receiver.getFeedbacks().contains(this)) {
-            receiver.getFeedbacks().add(this);
-        }
-    }
-
-    public void like(){
-        if(!liked) {
+    public void like() {
+        if (!liked) {
             this.liked = true;
         }
     }
 
-    public void unlike(){
-        if(liked) {
+    public void unlike() {
+        if (liked) {
             this.liked = false;
+        }
+    }
+
+    private void validateObjectiveFeedbacksCategory() {
+        if (!(MIN_OBJECTIVE_FEEDBACK_SIZE <= objectiveFeedbacks.size()
+              && objectiveFeedbacks.size() <= MAX_OBJECTIVE_FEEDBACK_SIZE)) {
+            throw new IllegalArgumentException("객관식 피드백은 " + MIN_OBJECTIVE_FEEDBACK_SIZE + "개 이상 " + MAX_OBJECTIVE_FEEDBACK_SIZE + "개 이하만 가능합니다.");
+        }
+        for (ObjectiveFeedback objectiveFeedback : objectiveFeedbacks) {
+            if (!feedbackCategory.isValidObjectiveFeedback(objectiveFeedback)) {
+                throw new IllegalArgumentException("피드백 카테고리와 일치하지 않는 객관식 피드백입니다: " + objectiveFeedback);
+            }
+        }
+    }
+
+    private void setReceiver(Member receiver) {
+        if (this.receiver != null) {
+            this.receiver.getFeedbacks().remove(this);
+        }
+        this.receiver = receiver;
+        if (receiver != null && !receiver.getFeedbacks().contains(this)) {
+            receiver.getFeedbacks().add(this);
         }
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/FeedbackCategory.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/FeedbackCategory.java
@@ -1,0 +1,30 @@
+package com.feedhanjum.back_end.feedback.domain;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public enum FeedbackCategory {
+    POSITIVE, CONSTRUCTIVE;
+
+    private static final Map<FeedbackCategory, List<ObjectiveFeedback>> OBJECTIVE_FEEDBACKS;
+
+    static {
+        OBJECTIVE_FEEDBACKS = new EnumMap<>(FeedbackCategory.class);
+        for (ObjectiveFeedback objectiveFeedback : ObjectiveFeedback.values()) {
+            OBJECTIVE_FEEDBACKS
+                    .computeIfAbsent(objectiveFeedback.getCategory(), discard -> new ArrayList<>())
+                    .add(objectiveFeedback);
+        }
+    }
+
+    public boolean isValidObjectiveFeedback(ObjectiveFeedback objectiveFeedback) {
+        return this == objectiveFeedback.getCategory();
+    }
+
+    // 카테고리별 허용된 객관식 피드백 목록 반환
+    public List<ObjectiveFeedback> getObjectiveFeedbacks() {
+        return OBJECTIVE_FEEDBACKS.get(this);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/ObjectiveFeedback.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/ObjectiveFeedback.java
@@ -1,0 +1,67 @@
+package com.feedhanjum.back_end.feedback.domain;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public enum ObjectiveFeedback {
+    LOGICAL(FeedbackCategory.POSITIVE, "논리적으로 말해요"),
+    CREATIVE(FeedbackCategory.POSITIVE, "창의적이에요"),
+    FAST_WORKER(FeedbackCategory.POSITIVE, "일처리가 빨라요"),
+    TOOL_SAVVY(FeedbackCategory.POSITIVE, "툴 활용에 능숙해요"),
+
+    LISTENER(FeedbackCategory.POSITIVE, "다른 사람의 의견을 경청해요"),
+    LEADERSHIP(FeedbackCategory.POSITIVE, "리더십이 돋보여요"),
+    HELPFUL(FeedbackCategory.POSITIVE, "많은 도움을 줘요"),
+    COLLABORATIVE(FeedbackCategory.POSITIVE, "협력을 잘해요"),
+    DETAIL_ORIENTED(FeedbackCategory.POSITIVE, "꼼꼼해요"),
+
+    RESPONSIBLE(FeedbackCategory.POSITIVE, "책임감이 있어요"),
+    PROACTIVE(FeedbackCategory.POSITIVE, "적극적이에요"),
+    POSITIVE(FeedbackCategory.POSITIVE, "긍정적이에요"),
+    DILIGENT(FeedbackCategory.POSITIVE, "성실해요"),
+    HARDWORKING(FeedbackCategory.POSITIVE, "노력이 느껴져요"),
+
+    LOGICAL_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "논리적으로 말해주세요"),
+    CONCISE_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "요점 위주로 얘기해주세요"),
+    DETAILED_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "구체적으로 말해주세요"),
+    THOROUGH_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "조금 더 꼼꼼히 준비해주세요"),
+    TOOL_INEXPERIENCED(FeedbackCategory.CONSTRUCTIVE, "툴 활용에 미숙해요"),
+
+    LISTEN_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "다른 사람의 의견을 경청해주세요"),
+    INITIATIVE_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "주도적으로 참여해주세요"),
+    POLITE_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "상대방을 배려해 부드럽게 말씀해주세요"),
+
+    RESPONSIBLE_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "책임감을 발휘해주세요"),
+    PROACTIVE_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "적극적으로 참여해주세요"),
+    RATIONAL_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "감정적인 표현을 지양해주세요"),
+    FOCUS_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "조금 더 집중해주세요"),
+    PUNCTUAL_REQUIRED(FeedbackCategory.CONSTRUCTIVE, "시간 약속을 지켜주세요");
+
+    private static final Map<String, ObjectiveFeedback> FEEDBACK_MAP;
+
+    static {
+        FEEDBACK_MAP = new HashMap<>();
+        for (ObjectiveFeedback feedback : values()) {
+            FEEDBACK_MAP.put(feedback.content, feedback);
+        }
+    }
+
+    @Getter
+    private final FeedbackCategory category;
+    @Getter
+    private final String content;
+
+    ObjectiveFeedback(FeedbackCategory category, String content) {
+        this.category = category;
+        this.content = content;
+    }
+
+
+    public static Optional<ObjectiveFeedback> from(String content) {
+        return Optional.ofNullable(FEEDBACK_MAP.get(content));
+    }
+
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FrequentFeedbackCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FrequentFeedbackCreatedEvent.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.feedback.event;
+
+import lombok.Getter;
+
+@Getter
+public class FrequentFeedbackCreatedEvent {
+    private final Long feedbackId;
+
+    public FrequentFeedbackCreatedEvent(Long feedbackId) {
+        this.feedbackId = feedbackId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/repository/FeedbackRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,7 @@
+package com.feedhanjum.back_end.feedback.repository;
+
+import com.feedhanjum.back_end.feedback.domain.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -1,0 +1,57 @@
+package com.feedhanjum.back_end.feedback.service;
+
+import com.feedhanjum.back_end.event.EventPublisher;
+import com.feedhanjum.back_end.feedback.domain.Feedback;
+import com.feedhanjum.back_end.feedback.domain.FeedbackCategory;
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
+import com.feedhanjum.back_end.feedback.repository.FeedbackRepository;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+public class FeedbackService {
+    private final MemberRepository memberRepository;
+    private final TeamRepository teamRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final EventPublisher eventPublisher;
+
+    public FeedbackService(MemberRepository memberRepository, TeamRepository teamRepository, FeedbackRepository feedbackRepository, EventPublisher eventPublisher) {
+        this.memberRepository = memberRepository;
+        this.teamRepository = teamRepository;
+        this.feedbackRepository = feedbackRepository;
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * @throws EntityNotFoundException  sender id, receiver id, team id에 해당하는 엔티티가 없을 경우
+     * @throws IllegalArgumentException 객관식 피드백이 보기에 없거나, 피드백 카테고리에 맞지 않는 값이 있을 경우, 또는 객관식 피드백이 1개 이상 5개 이하가 아닐 경우
+     */
+    @Transactional
+    public Feedback sendFrequentFeedback(Long senderId, Long receiverId, Long teamId, FeedbackType feedbackType, FeedbackCategory feedbackCategory, List<String> objectiveFeedbacks, String subjectiveFeedback) {
+        Member sender = memberRepository.findById(senderId).orElseThrow(() -> new EntityNotFoundException("sender id에 해당하는 member가 없습니다."));
+        Member receiver = memberRepository.findById(receiverId).orElseThrow(() -> new EntityNotFoundException("receiver id에 해당하는 member가 없습니다."));
+        Team team = teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("team id에 해당하는 team이 없습니다."));
+
+        Feedback feedback = Feedback.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .team(team)
+                .feedbackType(feedbackType)
+                .feedbackCategory(feedbackCategory)
+                .objectiveFeedbacks(objectiveFeedbacks)
+                .subjectiveFeedback(subjectiveFeedback)
+                .build();
+        feedbackRepository.save(feedback);
+        eventPublisher.publishEvent(new FrequentFeedbackCreatedEvent(feedback.getId()));
+        return feedback;
+
+    }
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -1,0 +1,230 @@
+package com.feedhanjum.back_end.feedback.service;
+
+import com.feedhanjum.back_end.event.EventPublisher;
+import com.feedhanjum.back_end.feedback.domain.Feedback;
+import com.feedhanjum.back_end.feedback.domain.FeedbackCategory;
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.feedback.domain.ObjectiveFeedback;
+import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
+import com.feedhanjum.back_end.feedback.repository.FeedbackRepository;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedbackServiceTest {
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private TeamRepository teamRepository;
+    @Mock
+    private FeedbackRepository feedbackRepository;
+    @Mock
+    private EventPublisher eventPublisher;
+    @InjectMocks
+    private FeedbackService feedbackService;
+
+    @Test
+    @DisplayName("피드백 전송 성공")
+    void test1() {
+        // given
+        Long senderId = 1L;
+        Long receiverId = 2L;
+        Long teamId = 3L;
+        Member sender = mock();
+        Member receiver = mock();
+        Team team = mock();
+
+        FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+        FeedbackCategory feedbackCategory = FeedbackCategory.POSITIVE;
+        List<String> objectiveFeedbacks = feedbackCategory.getObjectiveFeedbacks().subList(0, 2)
+                .stream().map(ObjectiveFeedback::getContent).toList();
+        String subjectiveFeedback = "좋아요";
+        when(memberRepository.findById(senderId)).thenReturn(Optional.of(sender));
+        when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(feedbackRepository.save(any(Feedback.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        Feedback feedback = feedbackService.sendFrequentFeedback(senderId, receiverId, teamId, feedbackType, feedbackCategory, objectiveFeedbacks, subjectiveFeedback);
+        // then
+        assertThat(feedback.getSender()).isEqualTo(sender);
+        assertThat(feedback.getReceiver()).isEqualTo(receiver);
+        assertThat(feedback.getTeam()).isEqualTo(team);
+        assertThat(feedback.getFeedbackType()).isEqualTo(feedbackType);
+        assertThat(feedback.getFeedbackCategory()).isEqualTo(feedbackCategory);
+        assertThat(feedback.getObjectiveFeedbacks()).extracting(ObjectiveFeedback::getContent)
+                .containsExactlyInAnyOrderElementsOf(objectiveFeedbacks);
+        assertThat(feedback.getSubjectiveFeedback()).isEqualTo(subjectiveFeedback);
+        assertThat(feedback.isLiked()).isFalse();
+
+        verify(eventPublisher).publishEvent(any(FrequentFeedbackCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("피드백 전송 실패 - sender가 없을 경우")
+    void test2() {
+        // given
+        Long senderId = 1L;
+        Long receiverId = 2L;
+        Long teamId = 3L;
+
+        FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+        FeedbackCategory feedbackCategory = FeedbackCategory.POSITIVE;
+        List<String> objectiveFeedbacks = feedbackCategory.getObjectiveFeedbacks().subList(0, 2)
+                .stream().map(ObjectiveFeedback::getContent).toList();
+        String subjectiveFeedback = "좋아요";
+        when(memberRepository.findById(senderId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedbackService.sendFrequentFeedback(senderId, receiverId, teamId, feedbackType, feedbackCategory, objectiveFeedbacks, subjectiveFeedback))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(eventPublisher, never()).publishEvent(any(FrequentFeedbackCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("피드백 전송 실패 - receiver가 없을 경우")
+    void test3() {
+        // given
+        Long senderId = 1L;
+        Long receiverId = 2L;
+        Long teamId = 3L;
+        Member sender = mock();
+
+        FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+        FeedbackCategory feedbackCategory = FeedbackCategory.POSITIVE;
+        List<String> objectiveFeedbacks = feedbackCategory.getObjectiveFeedbacks().subList(0, 2)
+                .stream().map(ObjectiveFeedback::getContent).toList();
+        String subjectiveFeedback = "좋아요";
+        when(memberRepository.findById(senderId)).thenReturn(Optional.of(sender));
+        when(memberRepository.findById(receiverId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedbackService.sendFrequentFeedback(senderId, receiverId, teamId, feedbackType, feedbackCategory, objectiveFeedbacks, subjectiveFeedback))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(eventPublisher, never()).publishEvent(any(FrequentFeedbackCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("피드백 전송 실패 - team이 없을 경우")
+    void test4() {
+        // given
+        Long senderId = 1L;
+        Long receiverId = 2L;
+        Long teamId = 3L;
+        Member sender = mock();
+        Member receiver = mock();
+
+        FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+        FeedbackCategory feedbackCategory = FeedbackCategory.POSITIVE;
+        List<String> objectiveFeedbacks = feedbackCategory.getObjectiveFeedbacks().subList(0, 2)
+                .stream().map(ObjectiveFeedback::getContent).toList();
+        String subjectiveFeedback = "좋아요";
+        when(memberRepository.findById(senderId)).thenReturn(Optional.of(sender));
+        when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
+        when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedbackService.sendFrequentFeedback(senderId, receiverId, teamId, feedbackType, feedbackCategory, objectiveFeedbacks, subjectiveFeedback))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(eventPublisher, never()).publishEvent(any(FrequentFeedbackCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("피드백 전송 실패 - 보기에 없는 객관식 피드백이 있을 경우")
+    void test5() {
+        // given
+        Long senderId = 1L;
+        Long receiverId = 2L;
+        Long teamId = 3L;
+        Member sender = mock();
+        Member receiver = mock();
+        Team team = mock();
+
+        FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+        FeedbackCategory feedbackCategory = FeedbackCategory.POSITIVE;
+        List<String> objectiveFeedbacks = List.of("존재하지 않는 객관식 피드백 값");
+        String subjectiveFeedback = "좋아요";
+        when(memberRepository.findById(senderId)).thenReturn(Optional.of(sender));
+        when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+
+        // when & then
+        assertThatThrownBy(() -> feedbackService.sendFrequentFeedback(senderId, receiverId, teamId, feedbackType, feedbackCategory, objectiveFeedbacks, subjectiveFeedback))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(eventPublisher, never()).publishEvent(any(FrequentFeedbackCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("피드백 전송 실패 - 카테고리에 맞지 않는 객관식 피드백이 있을 경우")
+    void test6() {
+        // given
+        Long senderId = 1L;
+        Long receiverId = 2L;
+        Long teamId = 3L;
+        Member sender = mock();
+        Member receiver = mock();
+        Team team = mock();
+
+        FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+        FeedbackCategory feedbackCategory = FeedbackCategory.POSITIVE;
+        List<String> objectiveFeedbacks = FeedbackCategory.CONSTRUCTIVE.getObjectiveFeedbacks().subList(0, 1)
+                .stream().map(ObjectiveFeedback::getContent).toList();
+        String subjectiveFeedback = "좋아요";
+        when(memberRepository.findById(senderId)).thenReturn(Optional.of(sender));
+        when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+
+        // when & then
+        assertThatThrownBy(() -> feedbackService.sendFrequentFeedback(senderId, receiverId, teamId, feedbackType, feedbackCategory, objectiveFeedbacks, subjectiveFeedback))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(eventPublisher, never()).publishEvent(any(FrequentFeedbackCreatedEvent.class));
+    }
+
+    @Test
+    @DisplayName("피드백 전송 실패 - 객관식 피드백 개수가 1~5개가 아닌 경우")
+    void test7() {
+        // given
+        Long senderId = 1L;
+        Long receiverId = 2L;
+        Long teamId = 3L;
+        Member sender = mock();
+        Member receiver = mock();
+        Team team = mock();
+
+        FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+        FeedbackCategory feedbackCategory = FeedbackCategory.POSITIVE;
+        List<String> objectiveFeedbacks = FeedbackCategory.CONSTRUCTIVE.getObjectiveFeedbacks().subList(0, 6)
+                .stream().map(ObjectiveFeedback::getContent).toList();
+        String subjectiveFeedback = "좋아요";
+        when(memberRepository.findById(senderId)).thenReturn(Optional.of(sender));
+        when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+
+        // when & then
+        assertThatThrownBy(() -> feedbackService.sendFrequentFeedback(senderId, receiverId, teamId, feedbackType, feedbackCategory, objectiveFeedbacks, subjectiveFeedback))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(eventPublisher, never()).publishEvent(any(FrequentFeedbackCreatedEvent.class));
+    }
+}


### PR DESCRIPTION
# 관련 이슈
FD-37

# 변경된 점
- 이벤트 발행 기능 추가
  - EventPublisher: 이벤트 발행을 담당하는 인터페이스
  - SpringEventPublisherImpl: Spring 의 ApplicationEventPublisher를 사용해 이벤트를 발행하는 구현체
- FeedbackRepository 추가
- 객관식 피드백 관련 enum 추가
  - FeedbackCategory: 긍정적/ 건설적 두가지 값을 갖는 enum
  - ObjectiveFeedback: 객관식 피드백에서 1개의 보기를 나태내는 enum. FeedbackCategory별로 허용된 ObjectiveFeedback을 검증할 수 있게 구현
- 수시 피드백 작성 구현: FeedbackService.sendFrequentFeedback

# 의논할 점
객관식 피드백 보기를 enum을 통해 코드에 박아넣었는데, 이것보다 더 좋은 방법이 있을까요? 데이터베이스에 보기를 저장하게 될 경우 도메인 객체만 가지고는 검증이 어렵고, 추가적인 db 조회 로직이 들어가야 할 것 같더라고요. 혹시 의견 있으시면 부탁드립니다.