### PR TITLE
[FD-241]  팀장 정보 팀 도메인으로 이동

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -1,6 +1,7 @@
 package com.feedhanjum.back_end.team.domain;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.schedule.domain.Schedule;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -35,10 +36,15 @@ public class Team {
     @OneToMany(mappedBy = "team")
     private final List<Schedule> schedules = new ArrayList<>();
 
-    public Team(FeedbackType feedbackType, String name, LocalDateTime startTime, LocalDateTime endTime) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private Member leader;
+
+    public Team(String name, Member leader, LocalDateTime startTime, LocalDateTime endTime, FeedbackType feedbackType) {
         this.feedbackType = feedbackType;
         this.name = name;
         this.startTime = startTime;
         this.endTime = endTime;
+        this.leader = leader;
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamMember.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamMember.java
@@ -30,12 +30,7 @@ public class TeamMember {
     @OneToMany(mappedBy = "teamMember")
     private final List<FrequentFeedbackRequest> frequentFeedbackRequests = new ArrayList<>();
 
-    @Enumerated(EnumType.STRING)
-    private TeamRole role;
-
-
-    public TeamMember(Team team, Member member, TeamRole role) {
-        this.role = role;
+    public TeamMember(Team team, Member member) {
         setTeam(team);
         setMember(member);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamRole.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamRole.java
@@ -1,5 +1,0 @@
-package com.feedhanjum.back_end.team.domain;
-
-public enum TeamRole {
-    LEADER, MEMBER
-}


### PR DESCRIPTION
# 관련 이슈
FD-241

# 변경된 점
- 팀 리더 관련 정보를 TeamMember.role -> Team.leader 로 이동
- 미사용 TeamRole 삭제