### PR TITLE
[FD-235] 세션 조회용 ArgumentResolver 생성

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
@@ -1,12 +1,16 @@
 package com.feedhanjum.back_end.auth.config;
 
 import com.feedhanjum.back_end.auth.infra.AuthInterceptor;
+import com.feedhanjum.back_end.auth.infra.LoginMemberArgumentResolver;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -29,6 +33,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginMemberArgumentResolver());
     }
 
     @Bean

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/exception/AuthExceptionHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/exception/AuthExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.feedhanjum.back_end.auth.exception;
 
-import com.feedhanjum.back_end.auth.controller.dto.MemberSignupResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,6 +33,20 @@ public class AuthExceptionHandler {
     public ResponseEntity<Map<String, String>> invalidCredentials(InvalidCredentialsException e) {
         Map<String, String> errorResponse = new HashMap<>();
         errorResponse.put("error", "INVALID_CREDENTIALS");
+        errorResponse.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+    /**
+     * 사용자가 로그인 상태가 아닐 경우
+     *
+     * @param e
+     * @return
+     */
+    @ExceptionHandler(LoginStateRequiredException.class)
+    public ResponseEntity<Map<String, String>> loginStateRequired(LoginStateRequiredException e) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "LOGIN_STATE_REQUIRED");
         errorResponse.put("message", e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/exception/LoginStateRequiredException.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/exception/LoginStateRequiredException.java
@@ -1,0 +1,7 @@
+package com.feedhanjum.back_end.auth.exception;
+
+public class LoginStateRequiredException extends RuntimeException {
+    public LoginStateRequiredException(String message) {
+        super(message);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/AuthInterceptor.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/AuthInterceptor.java
@@ -6,6 +6,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.web.servlet.HandlerInterceptor;
 
+/**
+ * @throws LoginStateRequiredException 사용자가 로그인하지 않은 상태인 경우
+ */
 public class AuthInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/AuthInterceptor.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/AuthInterceptor.java
@@ -1,5 +1,6 @@
 package com.feedhanjum.back_end.auth.infra;
 
+import com.feedhanjum.back_end.auth.exception.LoginStateRequiredException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -13,9 +14,6 @@ public class AuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
-        response.getWriter().write("{\"error\":\"UNAUTHORIZED\",\"message\":\"로그인이 필요합니다.\"}");
-        return false;
+        throw new LoginStateRequiredException("로그인이 필요합니다.");
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/Login.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/Login.java
@@ -1,0 +1,11 @@
+package com.feedhanjum.back_end.auth.infra;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface Login {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/LoginMemberArgumentResolver.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/LoginMemberArgumentResolver.java
@@ -17,8 +17,11 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         return hasLoginAnnotation && hasLongType;
     }
 
+    /**
+     * @throws LoginStateRequiredException 사용자가 로그인하지 않은 상태인 경우
+     */
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         HttpSession session = request.getSession(false);
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/LoginMemberArgumentResolver.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/LoginMemberArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.feedhanjum.back_end.auth.infra;
+
+import com.feedhanjum.back_end.auth.exception.LoginStateRequiredException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+        boolean hasLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginAnnotation && hasLongType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            throw new LoginStateRequiredException("로그인이 필요합니다.");
+        }
+        Object memberId = session.getAttribute(SessionConst.MEMBER_ID);
+        if (memberId == null) {
+            throw new LoginStateRequiredException("로그인이 필요합니다.");
+        }
+
+        return memberId;
+    }
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/auth/infra/LoginMemberArgumentResolverTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/auth/infra/LoginMemberArgumentResolverTest.java
@@ -1,0 +1,132 @@
+package com.feedhanjum.back_end.auth.infra;
+
+import com.feedhanjum.back_end.auth.exception.LoginStateRequiredException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LoginMemberArgumentResolverTest {
+
+    private LoginMemberArgumentResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new LoginMemberArgumentResolver();
+    }
+
+    @Test
+    @DisplayName("Login 어노테이션과 Long 타입인 경우 supportsParameter가 true를 반환한다")
+    void supportsParameter_true_when_loginAnnotation_and_LongType() throws Exception {
+        //given
+        Method method = DummyController.class.getMethod("methodWithLogin", Long.class);
+        MethodParameter parameter = new MethodParameter(method, 0);
+        //when
+        boolean supports = resolver.supportsParameter(parameter);
+        //then
+        assertThat(supports).isTrue();
+    }
+
+    @Test
+    @DisplayName("Login 어노테이션이 없으면 supportsParameter가 false를 반환한다")
+    void supportsParameter_false_when_no_loginAnnotation() throws Exception {
+        //given
+        Method method = DummyController.class.getMethod("methodWithoutLogin", Long.class);
+        MethodParameter parameter = new MethodParameter(method, 0);
+        //when
+        boolean supports = resolver.supportsParameter(parameter);
+        //then
+        assertThat(supports).isFalse();
+    }
+
+    @Test
+    @DisplayName("파라미터 타입이 Long이 아니면 supportsParameter가 false를 반환한다")
+    void supportsParameter_false_when_type_not_Long() throws Exception {
+        //given
+        Method method = DummyController.class.getMethod("methodWithLoginWrongType", String.class);
+        MethodParameter parameter = new MethodParameter(method, 0);
+        //when
+        boolean supports = resolver.supportsParameter(parameter);
+        //then
+        assertThat(supports).isFalse();
+    }
+
+    @Test
+    @DisplayName("세션에 MEMBER_ID가 있으면 resolveArgument가 해당 값을 반환한다")
+    void resolveArgument_returns_memberId_when_session_has_memberId() {
+        //given
+        NativeWebRequest webRequest = mock(NativeWebRequest.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+        Object memberId = 1L;
+        when(webRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(request);
+        when(request.getSession(false)).thenReturn(session);
+        when(session.getAttribute(SessionConst.MEMBER_ID)).thenReturn(memberId);
+        MethodParameter parameter = mock(MethodParameter.class);
+        ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+        WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+        //when
+        Object result = resolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+        //then
+        assertThat(result).isEqualTo(memberId);
+    }
+
+    @Test
+    @DisplayName("세션이 없으면 resolveArgument가 LoginStateRequiredException을 발생시킨다")
+    void resolveArgument_throws_exception_when_no_session() {
+        //given
+        NativeWebRequest webRequest = mock(NativeWebRequest.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(webRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(request);
+        when(request.getSession(false)).thenReturn(null);
+        MethodParameter parameter = mock(MethodParameter.class);
+        ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+        WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+        //when & then
+        assertThatThrownBy(() -> resolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory))
+                .isInstanceOf(LoginStateRequiredException.class)
+                .hasMessage("로그인이 필요합니다.");
+    }
+
+    @Test
+    @DisplayName("세션에 MEMBER_ID가 없으면 resolveArgument가 LoginStateRequiredException을 발생시킨다")
+    void resolveArgument_throws_exception_when_no_memberId_in_session() {
+        //given
+        NativeWebRequest webRequest = mock(NativeWebRequest.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+        when(webRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(request);
+        when(request.getSession(false)).thenReturn(session);
+        when(session.getAttribute(SessionConst.MEMBER_ID)).thenReturn(null);
+        MethodParameter parameter = mock(MethodParameter.class);
+        ModelAndViewContainer mavContainer = mock(ModelAndViewContainer.class);
+        WebDataBinderFactory binderFactory = mock(WebDataBinderFactory.class);
+        //when & then
+        assertThatThrownBy(() -> resolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory))
+                .isInstanceOf(LoginStateRequiredException.class)
+                .hasMessage("로그인이 필요합니다.");
+    }
+
+    static class DummyController {
+        public void methodWithLogin(@Login Long memberId) {
+        }
+
+        public void methodWithoutLogin(Long memberId) {
+        }
+
+        public void methodWithLoginWrongType(@Login String memberId) {
+        }
+    }
+}


### PR DESCRIPTION
# 관련 이슈
FD-235

# 변경된 점
- [x] 로그인 상태를 확인하는 LoginStateRequiredException 예외 생성
- [x] 로그인 인터셉터 로직의 거절 처리 방식을 false 에서 throw new LoginStateRequiredException 으로 변환
- [x] @Login 으로 Long memberId를 받아올 수 있는 LoginMemberArgumentResolver 생성 및 등록
- [x] 로그인 상태 검증 인터셉터 테스트 코드 변경
- [x] LoginMemberArgumentResolver의 테스트 코드 작성
# 의논할 점
인터셉터의 거절 로직을 false 가 아니라 예외를 던지는 것으로 변환했는데,
예외를 던짐으로써 로그인 상태 확인에 대한 응집도가 올라가고 
getWriter().wirte() 대신 단순 예외를 던짐으로써 코드 가독성이 올라가긴 했지만,
인터셉터의 고유 기능인 단순 거절 대신 사용한 것이기에 "이게 인터셉터가 맞나?"라는 책임의 모호함이 생긴 것 같습니다 ㅋㅋ
이에 대해서 어떻게 생각하시는지 궁금합니다!