### PR TITLE
[FD-8] 회원 활동명 변경 구현

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/core/exception/InternalErrorControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/exception/InternalErrorControllerAdvice.java
@@ -1,0 +1,19 @@
+package com.feedhanjum.back_end.core.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(2)
+@RestControllerAdvice
+@Slf4j
+public class InternalErrorControllerAdvice {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Void> handleException(Exception e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.feedhanjum.back_end.member.controller;
 
+import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
 import com.feedhanjum.back_end.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,6 +19,12 @@ public class MemberController {
     @GetMapping("/member/{id}")
     public ResponseEntity<MemberDto> getMemberById(@PathVariable Long id) {
         MemberDto memberDto = new MemberDto(memberService.getMemberById(id));
+        return new ResponseEntity<>(memberDto, HttpStatus.OK);
+    }
+
+    @PostMapping("/member/name")
+    public ResponseEntity<MemberDto> changeName(@Login Long memberId, String name) {
+        MemberDto memberDto = new MemberDto(memberService.changeName(memberId, name));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -3,6 +3,8 @@ package com.feedhanjum.back_end.member.controller;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
 import com.feedhanjum.back_end.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,7 +15,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/member/{id}")
-    public MemberDto getMemberById(@PathVariable Long id) {
-        return new MemberDto(memberService.getMemberById(id));
+    public ResponseEntity<MemberDto> getMemberById(@PathVariable Long id) {
+        MemberDto memberDto = new MemberDto(memberService.getMemberById(id));
+        return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -6,10 +6,7 @@ import com.feedhanjum.back_end.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,7 +20,7 @@ public class MemberController {
     }
 
     @PostMapping("/member/name")
-    public ResponseEntity<MemberDto> changeName(@Login Long memberId, String name) {
+    public ResponseEntity<MemberDto> changeName(@Login Long memberId, @RequestParam String name) {
         MemberDto memberDto = new MemberDto(memberService.changeName(memberId, name));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
@@ -47,4 +47,8 @@ public class Member {
     public void changeProfile(ProfileImage profileImage) {
         this.profileImage = profileImage;
     }
+
+    public void changeName(String name) {
+        this.name = name;
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.feedhanjum.back_end.member.service;
 
+import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,13 @@ public class MemberService {
         // 이거 이럴 일이 없겠지만, 동시성 문제 발생할지 모르니 혹시 몰라서 남겨둡니다.
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
         loginMember.changeName(name);
+        return loginMember;
+    }
+
+    @Transactional
+    public Member changeProfileImage(@Login Long memberId, ProfileImage profileImage) {
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
+        loginMember.changeProfile(profileImage);
         return loginMember;
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.feedhanjum.back_end.member.service;
 
+import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -20,5 +21,13 @@ public class MemberService {
         Member findMember = memberRepository.findById(findMemberId).orElseThrow(() -> new EntityNotFoundException("찾으려는 해당 사용자가 없습니다."));
         // 나중에 soft delete 구현 시, 탈퇴한 회원 여부를 검사해야 함.
         return findMember;
+    }
+
+    @Transactional
+    public Member changeName(@Login Long memberId, String name) {
+        // 이거 이럴 일이 없겠지만, 동시성 문제 발생할지 모르니 혹시 몰라서 남겨둡니다.
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
+        loginMember.changeName(name);
+        return loginMember;
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.feedhanjum.back_end.member.service;
 
-import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -33,7 +32,7 @@ public class MemberService {
     }
 
     @Transactional
-    public Member changeProfileImage(@Login Long memberId, ProfileImage profileImage) {
+    public Member changeProfileImage(Long memberId, ProfileImage profileImage) {
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
         loginMember.changeProfile(profileImage);
         return loginMember;

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.feedhanjum.back_end.member.service;
 
-import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -24,7 +23,7 @@ public class MemberService {
     }
 
     @Transactional
-    public Member changeName(@Login Long memberId, String name) {
+    public Member changeName(Long memberId, String name) {
         // 이거 이럴 일이 없겠지만, 동시성 문제 발생할지 모르니 혹시 몰라서 남겨둡니다.
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
         loginMember.changeName(name);

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -44,5 +45,22 @@ class MemberControllerTest {
         assertThat(result.getBody().email()).isEqualTo("hong@example.com");
         assertThat(result.getBody().profileImage().getBackgroundColor()).isEqualTo("blue");
         assertThat(result.getBody().profileImage().getImage()).isEqualTo("img.png");
+    }
+
+    @Test
+    @DisplayName("회원 이름 변경 컨트롤러 동작 확인")
+    void changeName_이름변경() {
+        // given
+        Long memberId = 1L;
+        String newName = "hoho";
+        Member member = new Member(newName, "hoho", new ProfileImage("huhu", "hehe"));
+        when(memberService.changeName(memberId, newName)).thenReturn(member);
+        // when
+        ResponseEntity<MemberDto> response = memberController.changeName(memberId, newName);
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        MemberDto memberDto = response.getBody();
+        assertThat(memberDto).isNotNull();
+        assertThat(memberDto.name()).isEqualTo(newName);
     }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,14 +35,14 @@ class MemberControllerTest {
         when(memberService.getMemberById(memberId)).thenReturn(member);
 
         //when
-        MemberDto result = memberController.getMemberById(memberId);
+        ResponseEntity<MemberDto> result = memberController.getMemberById(memberId);
 
         //then
-        assertThat(result).isNotNull();
-        assertThat(result.id()).isEqualTo(memberId);
-        assertThat(result.name()).isEqualTo("홍길동");
-        assertThat(result.email()).isEqualTo("hong@example.com");
-        assertThat(result.profileImage().getBackgroundColor()).isEqualTo("blue");
-        assertThat(result.profileImage().getImage()).isEqualTo("img.png");
+        assertThat(result.getBody()).isNotNull();
+        assertThat(result.getBody().id()).isEqualTo(memberId);
+        assertThat(result.getBody().name()).isEqualTo("홍길동");
+        assertThat(result.getBody().email()).isEqualTo("hong@example.com");
+        assertThat(result.getBody().profileImage().getBackgroundColor()).isEqualTo("blue");
+        assertThat(result.getBody().profileImage().getImage()).isEqualTo("img.png");
     }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/domain/MemberTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/domain/MemberTest.java
@@ -1,0 +1,55 @@
+package com.feedhanjum.back_end.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("회원 생성 시 필드가 정상적으로 초기화되는지 테스트")
+    void memberConstructor_회원생성() {
+        // given
+        ProfileImage profileImage = new ProfileImage("blue", "default.png");
+
+        // when
+        Member member = new Member("haha", "haha@example.com", profileImage);
+
+        // then
+        assertThat(member.getName()).isEqualTo("haha");
+        assertThat(member.getEmail()).isEqualTo("haha@example.com");
+        assertThat(member.getProfileImage().getBackgroundColor()).isEqualTo("blue");
+        assertThat(member.getProfileImage().getImage()).isEqualTo("default.png");
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 변경이 정상적으로 이루어지는지 테스트")
+    void changeProfile_프로필변경() {
+        // given
+        ProfileImage oldProfile = new ProfileImage("blue", "default.png");
+        ProfileImage newProfile = new ProfileImage("red", "new.png");
+        Member member = new Member("haha", "haha@example.com", oldProfile);
+
+        // when
+        member.changeProfile(newProfile);
+
+        // then
+        assertThat(member.getProfileImage().getBackgroundColor()).isEqualTo("red");
+        assertThat(member.getProfileImage().getImage()).isEqualTo("new.png");
+    }
+
+    @Test
+    @DisplayName("회원 이름 변경이 정상적으로 이루어지는지 테스트")
+    void changeName_이름변경() {
+        // given
+        ProfileImage profileImage = new ProfileImage("blue", "default.png");
+        Member member = new Member("haha", "haha@example.com", profileImage);
+
+        // when
+        member.changeName("hoho");
+
+        // then
+        assertThat(member.getName()).isEqualTo("hoho");
+    }
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/service/MemberServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/service/MemberServiceTest.java
@@ -60,4 +60,18 @@ class MemberServiceTest {
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("찾으려는 해당 사용자가 없습니다.");
     }
+
+    @Test
+    @DisplayName("회원 이름 변경에 성공한다")
+    void changeName_이름변경() {
+        // given
+        Long memberId = 1L;
+        Member member = new Member("haha", "hoho", new ProfileImage("huhu", "hehe"));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+        String newName = "hoho";
+        // when
+        Member result = memberService.changeName(memberId, newName);
+        // then
+        assertThat(result.getName()).isEqualTo(newName);
+    }
 }


### PR DESCRIPTION
# 관련 이슈
FD-8

# 변경된 점
- [x] 서버 내부 에러를 잡는 ControllerAdvice 구현
- [x] MemberController 가 객체를 곧바로 던지지 않도록 변경 -> ResponseEntity로 한번 감싸도록 변경
- [x] 회원 활동명 변경 로직 구현