### PR TITLE
[FD-35] 정기 피드백 전송

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/RegularFeedbackCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/RegularFeedbackCreatedEvent.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.feedback.event;
+
+import lombok.Getter;
+
+@Getter
+public class RegularFeedbackCreatedEvent {
+    private final Long feedbackId;
+
+    public RegularFeedbackCreatedEvent(Long feedbackId) {
+        this.feedbackId = feedbackId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -109,7 +109,7 @@ public class FeedbackService {
 
 
     /**
-     * @throws EntityNotFoundException           sender id, receiver id, schedule id에 해당하는 엔티티가 없을 경우
+     * @throws EntityNotFoundException           일정에 속한 sender, receiver가 없을 경우
      * @throws IllegalArgumentException          피드백 기분에 맞지 않는 객관식 피드백이 있을 경우, 또는 객관식 피드백이 1개 이상 5개 이하가 아닐 경우
      * @throws NoRegularFeedbackRequestException 정기 피드백 요청이 없을 경우
      */

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -6,9 +6,16 @@ import com.feedhanjum.back_end.feedback.domain.FeedbackFeeling;
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.feedback.domain.ObjectiveFeedback;
 import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
+import com.feedhanjum.back_end.feedback.event.RegularFeedbackCreatedEvent;
 import com.feedhanjum.back_end.feedback.repository.FeedbackRepository;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.schedule.domain.RegularFeedbackRequest;
+import com.feedhanjum.back_end.schedule.domain.Schedule;
+import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import com.feedhanjum.back_end.schedule.exception.NoRegularFeedbackRequestException;
+import com.feedhanjum.back_end.schedule.repository.RegularFeedbackRequestRepository;
+import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
 import com.feedhanjum.back_end.team.domain.FrequentFeedbackRequest;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
@@ -28,15 +35,19 @@ public class FeedbackService {
     private final TeamRepository teamRepository;
     private final FeedbackRepository feedbackRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final ScheduleMemberRepository scheduleMemberRepository;
     private final FrequentFeedbackRequestRepository frequentFeedbackRequestRepository;
+    private final RegularFeedbackRequestRepository regularFeedbackRequestRepository;
     private final EventPublisher eventPublisher;
 
-    public FeedbackService(MemberRepository memberRepository, TeamRepository teamRepository, FeedbackRepository feedbackRepository, TeamMemberRepository teamMemberRepository, FrequentFeedbackRequestRepository frequentFeedbackRequestRepository, EventPublisher eventPublisher) {
+    public FeedbackService(MemberRepository memberRepository, TeamRepository teamRepository, FeedbackRepository feedbackRepository, TeamMemberRepository teamMemberRepository, ScheduleMemberRepository scheduleMemberRepository, FrequentFeedbackRequestRepository frequentFeedbackRequestRepository, RegularFeedbackRequestRepository regularFeedbackRequestRepository, EventPublisher eventPublisher) {
         this.memberRepository = memberRepository;
         this.teamRepository = teamRepository;
         this.feedbackRepository = feedbackRepository;
         this.teamMemberRepository = teamMemberRepository;
+        this.scheduleMemberRepository = scheduleMemberRepository;
         this.frequentFeedbackRequestRepository = frequentFeedbackRequestRepository;
+        this.regularFeedbackRequestRepository = regularFeedbackRequestRepository;
         this.eventPublisher = eventPublisher;
     }
 
@@ -94,5 +105,45 @@ public class FeedbackService {
         TeamMember teamMember = teamMemberRepository.findByMemberIdAndTeamId(receiverId, teamId).orElseThrow(() -> new EntityNotFoundException("receiver 가 team 에 속해있지 않습니다"));
 
         return frequentFeedbackRequestRepository.findByTeamMember(teamMember);
+    }
+
+
+    /**
+     * @throws EntityNotFoundException           sender id, receiver id, schedule id에 해당하는 엔티티가 없을 경우
+     * @throws IllegalArgumentException          피드백 기분에 맞지 않는 객관식 피드백이 있을 경우, 또는 객관식 피드백이 1개 이상 5개 이하가 아닐 경우
+     * @throws NoRegularFeedbackRequestException 정기 피드백 요청이 없을 경우
+     */
+    @Transactional
+    public Feedback sendRegularFeedback(Long senderId, Long receiverId, Long scheduleId, FeedbackType feedbackType, FeedbackFeeling feedbackFeeling, List<ObjectiveFeedback> objectiveFeedbacks, String subjectiveFeedback) {
+        ScheduleMember senderScheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(senderId, scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("sender 가 schedule 에 속해있지 않습니다"));
+        ScheduleMember receiverScheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(receiverId, scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("receiver 가 schedule 에 속해있지 않습니다"));
+
+        Member sender = senderScheduleMember.getMember();
+        Member receiver = receiverScheduleMember.getMember();
+
+        Schedule schedule = senderScheduleMember.getSchedule();
+
+        // 정기 피드백을 보내려면 정기 피드백 요청이 있어야 함
+        RegularFeedbackRequest regularFeedbackRequest = regularFeedbackRequestRepository.findByRequesterAndScheduleMember(receiver, senderScheduleMember)
+                .orElseThrow(NoRegularFeedbackRequestException::new);
+
+        Team team = schedule.getTeam();
+
+        Feedback feedback = Feedback.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .team(team)
+                .feedbackType(feedbackType)
+                .feedbackFeeling(feedbackFeeling)
+                .objectiveFeedbacks(objectiveFeedbacks)
+                .subjectiveFeedback(subjectiveFeedback)
+                .build();
+        feedbackRepository.save(feedback);
+        regularFeedbackRequestRepository.delete(regularFeedbackRequest);
+        eventPublisher.publishEvent(new RegularFeedbackCreatedEvent(feedback.getId()));
+        return feedback;
+
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/domain/ScheduleMember.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/domain/ScheduleMember.java
@@ -21,11 +21,11 @@ public class ScheduleMember {
     @Enumerated(EnumType.STRING)
     private ScheduleRole role;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/exception/NoRegularFeedbackRequestException.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/exception/NoRegularFeedbackRequestException.java
@@ -1,0 +1,5 @@
+package com.feedhanjum.back_end.schedule.exception;
+
+// 정기 피드백 요청이 없었는데 정기 피드백을 보낼 경우 발생
+public class NoRegularFeedbackRequestException extends RuntimeException {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/RegularFeedbackRequestRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/RegularFeedbackRequestRepository.java
@@ -1,0 +1,13 @@
+package com.feedhanjum.back_end.schedule.repository;
+
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.schedule.domain.RegularFeedbackRequest;
+import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RegularFeedbackRequestRepository extends JpaRepository<RegularFeedbackRequest, Long> {
+
+    Optional<RegularFeedbackRequest> findByRequesterAndScheduleMember(Member requester, ScheduleMember scheduleMember);
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleMemberRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleMemberRepository.java
@@ -1,0 +1,11 @@
+package com.feedhanjum.back_end.schedule.repository;
+
+import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ScheduleMemberRepository extends JpaRepository<ScheduleMember, Long> {
+
+    Optional<ScheduleMember> findByMemberIdAndScheduleId(Long memberId, Long scheduleId);
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -6,9 +6,16 @@ import com.feedhanjum.back_end.feedback.domain.FeedbackFeeling;
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.feedback.domain.ObjectiveFeedback;
 import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
+import com.feedhanjum.back_end.feedback.event.RegularFeedbackCreatedEvent;
 import com.feedhanjum.back_end.feedback.repository.FeedbackRepository;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.schedule.domain.RegularFeedbackRequest;
+import com.feedhanjum.back_end.schedule.domain.Schedule;
+import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import com.feedhanjum.back_end.schedule.exception.NoRegularFeedbackRequestException;
+import com.feedhanjum.back_end.schedule.repository.RegularFeedbackRequestRepository;
+import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
 import com.feedhanjum.back_end.team.domain.FrequentFeedbackRequest;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
@@ -44,7 +51,11 @@ class FeedbackServiceTest {
     @Mock
     private TeamMemberRepository teamMemberRepository;
     @Mock
+    private ScheduleMemberRepository scheduleMemberRepository;
+    @Mock
     private FrequentFeedbackRequestRepository frequentFeedbackRequestRepository;
+    @Mock
+    private RegularFeedbackRequestRepository regularFeedbackRequestRepository;
     @Mock
     private EventPublisher eventPublisher;
     @InjectMocks
@@ -54,7 +65,7 @@ class FeedbackServiceTest {
     @DisplayName("sendFrequentFeedback 메서드 테스트")
     class SendFrequentFeedbackTest {
         @Test
-        @DisplayName("피드백 전송 성공")
+        @DisplayName("수시 피드백 전송 성공")
         void test1() {
             // given
             Long senderId = 1L;
@@ -90,7 +101,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 전송 실패 - sender가 없을 경우")
+        @DisplayName("수시 피드백 전송 실패 - sender가 없을 경우")
         void test2() {
             // given
             Long senderId = 1L;
@@ -111,7 +122,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 전송 실패 - receiver가 없을 경우")
+        @DisplayName("수시 피드백 전송 실패 - receiver가 없을 경우")
         void test3() {
             // given
             Long senderId = 1L;
@@ -134,7 +145,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 전송 실패 - team이 없을 경우")
+        @DisplayName("수시 피드백 전송 실패 - team이 없을 경우")
         void test4() {
             // given
             Long senderId = 1L;
@@ -159,7 +170,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 전송 실패 - 기분에 맞지 않는 객관식 피드백이 있을 경우")
+        @DisplayName("수시 피드백 전송 실패 - 기분에 맞지 않는 객관식 피드백이 있을 경우")
         void test6() {
             // given
             Long senderId = 1L;
@@ -185,7 +196,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 전송 실패 - 객관식 피드백 개수가 1~5개가 아닌 경우")
+        @DisplayName("수시 피드백 전송 실패 - 객관식 피드백 개수가 1~5개가 아닌 경우")
         void test7() {
             // given
             Long senderId = 1L;
@@ -216,7 +227,7 @@ class FeedbackServiceTest {
     @DisplayName("requestFrequentFeedback 메서드 테스트")
     class RequestFrequentFeedbackTest {
         @Test
-        @DisplayName("피드백 요청 성공")
+        @DisplayName("수시 피드백 요청 성공")
         void test1() {
             // given
             Long senderId = 1L;
@@ -250,7 +261,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 요청 실패 - sender가 없을 경우")
+        @DisplayName("수시 피드백 요청 실패 - sender가 없을 경우")
         void test2() {
             // given
             Long senderId = 1L;
@@ -269,7 +280,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 요청 실패 - receiver가 없을 경우")
+        @DisplayName("수시 피드백 요청 실패 - receiver가 없을 경우")
         void test3() {
             // given
             Long senderId = 1L;
@@ -290,7 +301,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 요청 실패 - team이 없을 경우")
+        @DisplayName("수시 피드백 요청 실패 - team이 없을 경우")
         void test4() {
             // given
             Long senderId = 1L;
@@ -313,7 +324,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 요청 실패 - sender가 team에 속하지 않았을 경우")
+        @DisplayName("수시 피드백 요청 실패 - sender가 team에 속하지 않았을 경우")
         void test5() {
             // given
             Long senderId = 1L;
@@ -338,7 +349,7 @@ class FeedbackServiceTest {
         }
 
         @Test
-        @DisplayName("피드백 요청 실패 - receiver가 team에 속하지 않았을 경우")
+        @DisplayName("수시 피드백 요청 실패 - receiver가 team에 속하지 않았을 경우")
         void test6() {
             // given
             Long senderId = 1L;
@@ -446,6 +457,220 @@ class FeedbackServiceTest {
             assertThatThrownBy(() -> feedbackService.getFrequentFeedbackRequests(receiverId, teamId))
                     .isInstanceOf(EntityNotFoundException.class);
 
+        }
+    }
+
+    @Nested
+    @DisplayName("sendRegularFeedback 메서드 테스트")
+    class SendRegularFeedbackTest {
+        @Test
+        @DisplayName("정기 피드백 전송 성공")
+        void test1() {
+            // given
+            Long senderId = 1L;
+            Long receiverId = 2L;
+            Long scheduleId = 3L;
+            Member sender = mock();
+            Member receiver = mock();
+            Team team = mock();
+            Schedule schedule = mock();
+            ScheduleMember senderMember = mock();
+            ScheduleMember receiverMember = mock();
+            RegularFeedbackRequest request = mock();
+
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(senderId, scheduleId)).thenReturn(Optional.of(senderMember));
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(receiverId, scheduleId)).thenReturn(Optional.of(receiverMember));
+
+            when(senderMember.getMember()).thenReturn(sender);
+            when(receiverMember.getMember()).thenReturn(receiver);
+            when(senderMember.getSchedule()).thenReturn(schedule);
+
+            when(regularFeedbackRequestRepository.findByRequesterAndScheduleMember(receiver, senderMember)).thenReturn(Optional.of(request));
+            when(schedule.getTeam()).thenReturn(team);
+
+            when(feedbackRepository.save(any(Feedback.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+            FeedbackFeeling feedbackFeeling = FeedbackFeeling.POSITIVE;
+            List<ObjectiveFeedback> objectiveFeedbacks = feedbackFeeling.getObjectiveFeedbacks().subList(0, 2);
+            String subjectiveFeedback = "좋아요";
+
+
+            // when
+            Feedback feedback = feedbackService.sendRegularFeedback(senderId, receiverId, scheduleId, feedbackType, feedbackFeeling, objectiveFeedbacks, subjectiveFeedback);
+            // then
+            assertThat(feedback.getSender()).isEqualTo(sender);
+            assertThat(feedback.getReceiver()).isEqualTo(receiver);
+            assertThat(feedback.getTeam()).isEqualTo(team);
+            assertThat(feedback.getFeedbackType()).isEqualTo(feedbackType);
+            assertThat(feedback.getFeedbackFeeling()).isEqualTo(feedbackFeeling);
+            assertThat(feedback.getObjectiveFeedbacks())
+                    .containsExactlyInAnyOrderElementsOf(objectiveFeedbacks);
+            assertThat(feedback.getSubjectiveFeedback()).isEqualTo(subjectiveFeedback);
+            assertThat(feedback.isLiked()).isFalse();
+
+            verify(regularFeedbackRequestRepository).delete(request);
+            verify(eventPublisher).publishEvent(any(RegularFeedbackCreatedEvent.class));
+        }
+
+        @Test
+        @DisplayName("정기 피드백 전송 실패 - sender가 일정에 속해있지 않을 경우")
+        void test2() {
+            // given
+            Long senderId = 1L;
+            Long receiverId = 2L;
+            Long scheduleId = 3L;
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(senderId, scheduleId)).thenReturn(Optional.empty());
+
+            FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+            FeedbackFeeling feedbackFeeling = FeedbackFeeling.POSITIVE;
+            List<ObjectiveFeedback> objectiveFeedbacks = feedbackFeeling.getObjectiveFeedbacks().subList(0, 2);
+            String subjectiveFeedback = "좋아요";
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService
+                    .sendRegularFeedback(senderId, receiverId, scheduleId, feedbackType, feedbackFeeling, objectiveFeedbacks, subjectiveFeedback))
+                    .isInstanceOf(EntityNotFoundException.class);
+
+            verify(eventPublisher, never()).publishEvent(any(RegularFeedbackCreatedEvent.class));
+
+        }
+
+        @Test
+        @DisplayName("정기 피드백 전송 실패 - receiver가 없을 경우")
+        void test3() {
+            // given
+            Long senderId = 1L;
+            Long receiverId = 2L;
+            Long scheduleId = 3L;
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(senderId, scheduleId)).thenReturn(Optional.empty());
+
+            FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+            FeedbackFeeling feedbackFeeling = FeedbackFeeling.POSITIVE;
+            List<ObjectiveFeedback> objectiveFeedbacks = feedbackFeeling.getObjectiveFeedbacks().subList(0, 2);
+            String subjectiveFeedback = "좋아요";
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService
+                    .sendRegularFeedback(senderId, receiverId, scheduleId, feedbackType, feedbackFeeling, objectiveFeedbacks, subjectiveFeedback))
+                    .isInstanceOf(EntityNotFoundException.class);
+
+            verify(eventPublisher, never()).publishEvent(any(RegularFeedbackCreatedEvent.class));
+        }
+
+        @Test
+        @DisplayName("정기 피드백 전송 실패 - 정기 피드백 요청이 없을 경우")
+        void test4() {
+            // given
+            Long senderId = 1L;
+            Long receiverId = 2L;
+            Long scheduleId = 3L;
+            Member sender = mock();
+            Member receiver = mock();
+            Schedule schedule = mock();
+            ScheduleMember senderMember = mock();
+            ScheduleMember receiverMember = mock();
+
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(senderId, scheduleId)).thenReturn(Optional.of(senderMember));
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(receiverId, scheduleId)).thenReturn(Optional.of(receiverMember));
+
+            when(senderMember.getMember()).thenReturn(sender);
+            when(receiverMember.getMember()).thenReturn(receiver);
+            when(senderMember.getSchedule()).thenReturn(schedule);
+
+            when(regularFeedbackRequestRepository.findByRequesterAndScheduleMember(receiver, senderMember)).thenReturn(Optional.empty());
+
+            FeedbackType feedbackType = FeedbackType.IDENTIFIED;
+            FeedbackFeeling feedbackFeeling = FeedbackFeeling.POSITIVE;
+            List<ObjectiveFeedback> objectiveFeedbacks = feedbackFeeling.getObjectiveFeedbacks().subList(0, 2);
+            String subjectiveFeedback = "좋아요";
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendRegularFeedback(senderId, receiverId, scheduleId, feedbackType, feedbackFeeling, objectiveFeedbacks, subjectiveFeedback))
+                    .isInstanceOf(NoRegularFeedbackRequestException.class);
+
+            verify(regularFeedbackRequestRepository, never()).delete(any());
+            verify(eventPublisher, never()).publishEvent(any(RegularFeedbackCreatedEvent.class));
+        }
+
+        @Test
+        @DisplayName("정기 피드백 전송 실패 - 기분에 맞지 않는 객관식 피드백이 있을 경우")
+        void test6() {
+            // given
+            Long senderId = 1L;
+            Long receiverId = 2L;
+            Long scheduleId = 3L;
+            Member sender = mock();
+            Member receiver = mock();
+            Team team = mock();
+            Schedule schedule = mock();
+            ScheduleMember senderMember = mock();
+            ScheduleMember receiverMember = mock();
+            RegularFeedbackRequest request = mock();
+
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(senderId, scheduleId)).thenReturn(Optional.of(senderMember));
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(receiverId, scheduleId)).thenReturn(Optional.of(receiverMember));
+
+            when(senderMember.getMember()).thenReturn(sender);
+            when(receiverMember.getMember()).thenReturn(receiver);
+            when(senderMember.getSchedule()).thenReturn(schedule);
+
+            when(regularFeedbackRequestRepository.findByRequesterAndScheduleMember(receiver, senderMember)).thenReturn(Optional.of(request));
+            when(schedule.getTeam()).thenReturn(team);
+
+            FeedbackType feedbackType = FeedbackType.ANONYMOUS;
+            FeedbackFeeling feedbackFeeling = FeedbackFeeling.CONSTRUCTIVE;
+            List<ObjectiveFeedback> objectiveFeedbacks = FeedbackFeeling.POSITIVE.getObjectiveFeedbacks().subList(0, 2);
+            String subjectiveFeedback = "좋아요";
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendRegularFeedback(senderId, receiverId, scheduleId, feedbackType, feedbackFeeling, objectiveFeedbacks, subjectiveFeedback))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(eventPublisher, never()).publishEvent(any(RegularFeedbackCreatedEvent.class));
+        }
+
+        @Test
+        @DisplayName("정기 피드백 전송 실패 - 객관식 피드백 개수가 1~5개가 아닌 경우")
+        void test7() {
+            // given
+            Long senderId = 1L;
+            Long receiverId = 2L;
+            Long scheduleId = 3L;
+            Member sender = mock();
+            Member receiver = mock();
+            Team team = mock();
+            Schedule schedule = mock();
+            ScheduleMember senderMember = mock();
+            ScheduleMember receiverMember = mock();
+            RegularFeedbackRequest request = mock();
+
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(senderId, scheduleId)).thenReturn(Optional.of(senderMember));
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(receiverId, scheduleId)).thenReturn(Optional.of(receiverMember));
+
+            when(senderMember.getMember()).thenReturn(sender);
+            when(receiverMember.getMember()).thenReturn(receiver);
+            when(senderMember.getSchedule()).thenReturn(schedule);
+
+            when(regularFeedbackRequestRepository.findByRequesterAndScheduleMember(receiver, senderMember)).thenReturn(Optional.of(request));
+            when(schedule.getTeam()).thenReturn(team);
+
+            FeedbackType feedbackType = FeedbackType.ANONYMOUS;
+            FeedbackFeeling feedbackFeeling = FeedbackFeeling.CONSTRUCTIVE;
+            List<ObjectiveFeedback> objectiveFeedbacks = feedbackFeeling.getObjectiveFeedbacks().subList(0, 6);
+            String subjectiveFeedback = "좋아요";
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.sendRegularFeedback(senderId, receiverId, scheduleId, feedbackType, feedbackFeeling, objectiveFeedbacks, subjectiveFeedback))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            verify(eventPublisher, never()).publishEvent(any(RegularFeedbackCreatedEvent.class));
         }
     }
 }


### PR DESCRIPTION
# 관련 이슈
FD-35

# 변경된 점
- 정기 피드백 전송 구현
  - 대응되는 정기 피드백 요청이 존재할 때만 사용 가능
  - 전송이 완료되면 대응되는 정기 피드백 요청이 삭제

- sender, recevier, schedule의 존재 여부 + 스케줄에 포함 여부를 검사하기 위해 ScheduleMember가 존재하는지로 한번에 확인