### PR TITLE
[FD-34] 정기 피드백 요청 생성

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/event/config/EventConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/event/config/EventConfig.java
@@ -1,0 +1,9 @@
+package com.feedhanjum.back_end.event.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class EventConfig {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -183,17 +183,20 @@ public class FeedbackService {
     }
 
     /**
+     * @throws IllegalStateException   schedule이 아직 끝나지 않았을 경우
      * @throws EntityNotFoundException schedule id에 해당하는 엔티티가 없을 경우
      */
     @Transactional
     public void createRegularFeedbackRequests(Long scheduleId) {
         Schedule schedule = scheduleRepository.findByIdWithMembers(scheduleId).orElseThrow(() -> new EntityNotFoundException("schedule id에 해당하는 schedule이 없습니다."));
+        if (!schedule.isEnd())
+            throw new IllegalStateException("schedule이 아직 끝나지 않았습니다.");
 
         List<RegularFeedbackRequest> requests = new ArrayList<>();
         LocalDateTime requestTime = schedule.getEndTime();
         for (ScheduleMember receiverMember : schedule.getScheduleMembers()) {
             for (ScheduleMember senderMember : schedule.getScheduleMembers()) {
-                if (senderMember.equals(receiverMember)) {
+                if (senderMember == receiverMember) {
                     continue;
                 }
                 requests.add(new RegularFeedbackRequest(requestTime, senderMember.getMember(), receiverMember));

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -14,9 +14,11 @@ import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.schedule.domain.RegularFeedbackRequest;
 import com.feedhanjum.back_end.schedule.domain.Schedule;
 import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import com.feedhanjum.back_end.schedule.event.RegularFeedbackRequestCreatedEvent;
 import com.feedhanjum.back_end.schedule.exception.NoRegularFeedbackRequestException;
 import com.feedhanjum.back_end.schedule.repository.RegularFeedbackRequestRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
+import com.feedhanjum.back_end.schedule.repository.ScheduleRepository;
 import com.feedhanjum.back_end.team.domain.FrequentFeedbackRequest;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
@@ -28,22 +30,26 @@ import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 public class FeedbackService {
     private final MemberRepository memberRepository;
     private final TeamRepository teamRepository;
-    private final FeedbackRepository feedbackRepository;
     private final TeamMemberRepository teamMemberRepository;
+    private final ScheduleRepository scheduleRepository;
     private final ScheduleMemberRepository scheduleMemberRepository;
+    private final FeedbackRepository feedbackRepository;
     private final FrequentFeedbackRequestRepository frequentFeedbackRequestRepository;
     private final RegularFeedbackRequestRepository regularFeedbackRequestRepository;
     private final EventPublisher eventPublisher;
 
-    public FeedbackService(MemberRepository memberRepository, TeamRepository teamRepository, FeedbackRepository feedbackRepository, TeamMemberRepository teamMemberRepository, ScheduleMemberRepository scheduleMemberRepository, FrequentFeedbackRequestRepository frequentFeedbackRequestRepository, RegularFeedbackRequestRepository regularFeedbackRequestRepository, EventPublisher eventPublisher) {
+    public FeedbackService(MemberRepository memberRepository, TeamRepository teamRepository, ScheduleRepository scheduleRepository, FeedbackRepository feedbackRepository, TeamMemberRepository teamMemberRepository, ScheduleMemberRepository scheduleMemberRepository, FrequentFeedbackRequestRepository frequentFeedbackRequestRepository, RegularFeedbackRequestRepository regularFeedbackRequestRepository, EventPublisher eventPublisher) {
         this.memberRepository = memberRepository;
         this.teamRepository = teamRepository;
+        this.scheduleRepository = scheduleRepository;
         this.feedbackRepository = feedbackRepository;
         this.teamMemberRepository = teamMemberRepository;
         this.scheduleMemberRepository = scheduleMemberRepository;
@@ -145,7 +151,7 @@ public class FeedbackService {
         eventPublisher.publishEvent(new RegularFeedbackCreatedEvent(feedback.getId()));
         return feedback;
     }
-  
+
     /**
      * @throws EntityNotFoundException feedback id에 해당하는 엔티티가 없을 경우
      * @throws SecurityException       해당 피드백의 receiver가 아닌 경우
@@ -175,4 +181,27 @@ public class FeedbackService {
         }
         feedback.unlike();
     }
+
+    /**
+     * @throws EntityNotFoundException schedule id에 해당하는 엔티티가 없을 경우
+     */
+    @Transactional
+    public void createRegularFeedbackRequests(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findByIdWithMembers(scheduleId).orElseThrow(() -> new EntityNotFoundException("schedule id에 해당하는 schedule이 없습니다."));
+
+        List<RegularFeedbackRequest> requests = new ArrayList<>();
+        LocalDateTime requestTime = schedule.getEndTime();
+        for (ScheduleMember receiverMember : schedule.getScheduleMembers()) {
+            for (ScheduleMember senderMember : schedule.getScheduleMembers()) {
+                if (senderMember.equals(receiverMember)) {
+                    continue;
+                }
+                requests.add(new RegularFeedbackRequest(requestTime, senderMember.getMember(), receiverMember));
+            }
+            // batch insert를 사용하도록 설정 필요
+            eventPublisher.publishEvent(new RegularFeedbackRequestCreatedEvent(receiverMember.getMember().getId(), scheduleId));
+        }
+        regularFeedbackRequestRepository.saveAll(requests);
+    }
+
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/domain/Schedule.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/domain/Schedule.java
@@ -22,7 +22,7 @@ public class Schedule {
     private String name;
 
     private LocalDateTime startTime;
-    
+
     private LocalDateTime endTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -30,7 +30,7 @@ public class Schedule {
     private Team team;
 
     @OneToMany(mappedBy = "schedule")
-    private List<ScheduleMember> scheduleMembers = new ArrayList<>();
+    private final List<ScheduleMember> scheduleMembers = new ArrayList<>();
 
     public Schedule(String name, LocalDateTime startTime, LocalDateTime endTime, Team team) {
         this.name = name;
@@ -39,12 +39,16 @@ public class Schedule {
         setTeam(team);
     }
 
+    public boolean isEnd() {
+        return LocalDateTime.now().isAfter(endTime);
+    }
+
     public void setTeam(Team team) {
         if (this.team != null) {
             this.team.getSchedules().remove(this);
         }
         this.team = team;
-        if(team != null && !team.getSchedules().contains(this)) {
+        if (team != null && !team.getSchedules().contains(this)) {
             team.getSchedules().add(this);
         }
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/RegularFeedbackRequestCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/RegularFeedbackRequestCreatedEvent.java
@@ -1,0 +1,14 @@
+package com.feedhanjum.back_end.schedule.event;
+
+import lombok.Getter;
+
+@Getter
+public class RegularFeedbackRequestCreatedEvent {
+    private final Long receiverId;
+    private final Long scheduleId;
+
+    public RegularFeedbackRequestCreatedEvent(Long receiverId, Long scheduleId) {
+        this.receiverId = receiverId;
+        this.scheduleId = scheduleId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleEndEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleEndEvent.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.schedule.event;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleEndEvent {
+    private final Long scheduleId;
+
+    public ScheduleEndEvent(Long scheduleId) {
+        this.scheduleId = scheduleId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/ScheduleEndEventListener.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/ScheduleEndEventListener.java
@@ -1,0 +1,24 @@
+package com.feedhanjum.back_end.schedule.event.handler;
+
+import com.feedhanjum.back_end.feedback.service.FeedbackService;
+import com.feedhanjum.back_end.schedule.event.ScheduleEndEvent;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class ScheduleEndEventListener {
+    private final FeedbackService feedbackService;
+
+    public ScheduleEndEventListener(FeedbackService feedbackService) {
+        this.feedbackService = feedbackService;
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void createRegularFeedbackRequests(ScheduleEndEvent event) {
+        Long scheduleId = event.getScheduleId();
+        feedbackService.createRegularFeedbackRequests(scheduleId);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,13 @@
+package com.feedhanjum.back_end.schedule.repository;
+
+import com.feedhanjum.back_end.schedule.domain.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+    @Query("select s from Schedule s join fetch s.scheduleMembers m join fetch m.member where s.id = :id")
+    Optional<Schedule> findByIdWithMembers(Long id);
+}


### PR DESCRIPTION
# 관련 이슈
FD-34

# 변경된 점
- 정기 피드백 요청 생성 기능 추가
  - 일정에 포함된 팀원 n명에 각각에게 자신을 제외한 n-1명에 대한 정기 피드백 요청을 생성.
- 일정 종료 이벤트 발생 시 이를 수신하여 정기 피드백 요청 생성으로 연결시키는 이벤트 리스너 추가 