### PR TITLE
[FD-234] 일정별 정기 피드백 요청 조회

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -103,15 +103,13 @@ public class FeedbackService {
     }
 
     /**
-     * @throws EntityNotFoundException receiver id, team id에 해당하는 엔티티가 없을 경우, receiver가 team에 속해있지 않을 경우
+     * @throws EntityNotFoundException receiver가 팀에 속해있지 않을 경우
      */
     @Transactional(readOnly = true)
     public List<FrequentFeedbackRequest> getFrequentFeedbackRequests(Long receiverId, Long teamId) {
-        memberRepository.findById(receiverId).orElseThrow(() -> new EntityNotFoundException("receiver id에 해당하는 member가 없습니다."));
-        teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("team id에 해당하는 team이 없습니다."));
         TeamMember teamMember = teamMemberRepository.findByMemberIdAndTeamId(receiverId, teamId).orElseThrow(() -> new EntityNotFoundException("receiver 가 team 에 속해있지 않습니다"));
 
-        return frequentFeedbackRequestRepository.findByTeamMember(teamMember);
+        return teamMember.getFrequentFeedbackRequests();
     }
 
     /**

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -215,4 +215,15 @@ public class FeedbackService {
 
         regularFeedbackRequestRepository.deleteAllByScheduleMember(scheduleMember);
     }
+
+    /**
+     * @throws EntityNotFoundException receiver가 team에 속해있지 않을 경우
+     */
+    @Transactional(readOnly = true)
+    public List<RegularFeedbackRequest> getRegularFeedbackRequests(Long receiverId, Long scheduleId) {
+        ScheduleMember scheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(receiverId, scheduleId)
+                .orElseThrow(() -> new EntityNotFoundException("receiver 가 schedule 에 속해있지 않습니다"));
+
+        return scheduleMember.getRegularFeedbackRequests();
+    }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -393,17 +393,11 @@ class FeedbackServiceTest {
             // given
             Long receiverId = 1L;
             Long teamId = 2L;
-            Member receiver = mock();
-            Team team = mock();
             TeamMember teamMember = mock();
             List<FrequentFeedbackRequest> requests = List.of(mock(), mock());
 
-
-            when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
-            when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
             when(teamMemberRepository.findByMemberIdAndTeamId(receiverId, teamId)).thenReturn(Optional.of(teamMember));
-            when(frequentFeedbackRequestRepository.findByTeamMember(teamMember)).thenReturn(requests);
-
+            when(teamMember.getFrequentFeedbackRequests()).thenReturn(requests);
 
             // when
             List<FrequentFeedbackRequest> result = feedbackService.getFrequentFeedbackRequests(receiverId, teamId);
@@ -412,39 +406,6 @@ class FeedbackServiceTest {
             assertThat(result).isEqualTo(requests);
         }
 
-        @Test
-        @DisplayName("수시 피드백 요청 조회 실패 - receiver가 없을 경우")
-        void test2() {
-            // given
-            Long receiverId = 1L;
-            Long teamId = 2L;
-
-            when(memberRepository.findById(receiverId)).thenReturn(Optional.empty());
-
-
-            // when & then
-            assertThatThrownBy(() -> feedbackService.getFrequentFeedbackRequests(receiverId, teamId))
-                    .isInstanceOf(EntityNotFoundException.class);
-
-        }
-
-        @Test
-        @DisplayName("수시 피드백 요청 조회 실패 - team이 없을 경우")
-        void test3() {
-            // given
-            Long receiverId = 1L;
-            Long teamId = 2L;
-            Member receiver = mock();
-
-
-            when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
-            when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> feedbackService.getFrequentFeedbackRequests(receiverId, teamId))
-                    .isInstanceOf(EntityNotFoundException.class);
-
-        }
 
         @Test
         @DisplayName("수시 피드백 요청 조회 실패 - receiver가 team에 속하지 않았을 경우")
@@ -452,12 +413,7 @@ class FeedbackServiceTest {
             // given
             Long receiverId = 1L;
             Long teamId = 2L;
-            Member receiver = mock();
-            Team team = mock();
 
-
-            when(memberRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
-            when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
             when(teamMemberRepository.findByMemberIdAndTeamId(receiverId, teamId)).thenReturn(Optional.empty());
 
             // when & then

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -927,4 +927,41 @@ class FeedbackServiceTest {
             verify(regularFeedbackRequestRepository, never()).deleteAllByScheduleMember(any());
         }
     }
+
+    @Nested
+    @DisplayName("getRegularFeedbackRequests 메서드 테스트")
+    class GetRegularFeedbackRequestsTest {
+        @Test
+        @DisplayName("정기 피드백 요청 조회 성공")
+        void test1() {
+            // given
+            Long memberId = 1L;
+            Long scheduleId = 2L;
+            ScheduleMember scheduleMember = mock();
+            List<RegularFeedbackRequest> requests = List.of(mock(), mock());
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, scheduleId)).thenReturn(Optional.of(scheduleMember));
+            when(scheduleMember.getRegularFeedbackRequests()).thenReturn(requests);
+
+            // when
+            List<RegularFeedbackRequest> result = feedbackService.getRegularFeedbackRequests(memberId, scheduleId);
+
+            // then
+            assertThat(result).isEqualTo(requests);
+        }
+
+        @Test
+        @DisplayName("정기 피드백 요청 조회 실패 - member가 일정에 속하지 않았을 경우")
+        void test2() {
+            // given
+            Long memberId = 1L;
+            Long scheduleId = 2L;
+
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, scheduleId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.getRegularFeedbackRequests(memberId, scheduleId))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
 }


### PR DESCRIPTION
# 관련 이슈
FD-234

# 변경된 점
- 일정별 정기 피드백 요청 조회 구현
- 수시 피드백 요청 조회 리팩터링
  - FrequentFeedbackRepository를 조회하는 대신 TeamMember.getFrequentFeedbackRequests() 사용