### PR TITLE
[FD-73] 수시 피드백 요청 모두 거절

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -226,4 +226,18 @@ public class FeedbackService {
 
         return scheduleMember.getRegularFeedbackRequests();
     }
+
+    /**
+     * 해당 팀에서 receiver에게 온 모든 수시 피드백 요청을 거절한다.
+     * 수시 피드백 요청 배너닫기 클릭 시 사용
+     *
+     * @throws EntityNotFoundException 팀에 속한 receiver가 없을 경우
+     */
+    @Transactional
+    public void rejectAllFrequentFeedbackRequests(Long receiverId, Long teamId) {
+        TeamMember teamMember = teamMemberRepository.findByMemberIdAndTeamId(receiverId, teamId)
+                .orElseThrow(() -> new EntityNotFoundException("receiver 가 team 에 속해있지 않습니다"));
+
+        frequentFeedbackRequestRepository.deleteAllByTeamMember(teamMember);
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -103,7 +103,7 @@ public class FeedbackService {
     }
 
     /**
-     * @throws EntityNotFoundException receiver가 팀에 속해있지 않을 경우
+     * @throws EntityNotFoundException 팀에 속한 receiver가 없을 경우
      */
     @Transactional(readOnly = true)
     public List<FrequentFeedbackRequest> getFrequentFeedbackRequests(Long receiverId, Long teamId) {
@@ -217,7 +217,7 @@ public class FeedbackService {
     }
 
     /**
-     * @throws EntityNotFoundException receiver가 team에 속해있지 않을 경우
+     * @throws EntityNotFoundException 일정에 속한 receiver가 없을 경우
      */
     @Transactional(readOnly = true)
     public List<RegularFeedbackRequest> getRegularFeedbackRequests(Long receiverId, Long scheduleId) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/FrequentFeedbackRequestRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/FrequentFeedbackRequestRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface FrequentFeedbackRequestRepository extends JpaRepository<FrequentFeedbackRequest, Long> {
     List<FrequentFeedbackRequest> findByTeamMember(TeamMember teamMember);
+
+    void deleteAllByTeamMember(TeamMember teamMember);
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -964,4 +964,39 @@ class FeedbackServiceTest {
                     .isInstanceOf(EntityNotFoundException.class);
         }
     }
+
+    @Nested
+    @DisplayName("rejectAllFrequentFeedbackRequests 메서드 테스트")
+    class RejectAllFrequentFeedbackRequestsTest {
+        @Test
+        @DisplayName("모든 수시 피드백 요청 거절 성공")
+        void test1() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 2L;
+            TeamMember teamMember = mock();
+
+            when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId)).thenReturn(Optional.of(teamMember));
+
+            // when
+            feedbackService.rejectAllFrequentFeedbackRequests(memberId, teamId);
+
+            // then
+            verify(frequentFeedbackRequestRepository).deleteAllByTeamMember(teamMember);
+        }
+
+        @Test
+        @DisplayName("모든 수시 피드백 요청 거절 실패 - member가 team에 속하지 않았을 경우")
+        void test2() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 2L;
+
+            when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> feedbackService.rejectAllFrequentFeedbackRequests(memberId, teamId))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
 }


### PR DESCRIPTION
# 관련 이슈
FD-73

# 변경된 점
- 수시 피드백 요청 전부 거절 구현
  - 추후 수시 피드백 배너 닫음 API 에서 사용 예정