### PR TITLE
[FD-13] 팀 생성 기능 추가

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class MemberController {
     private final MemberService memberService;
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
@@ -37,9 +37,9 @@ public class Member {
 
     @Override
     public final boolean equals(Object o) {
+        if (this == o) return true;
         if (o instanceof Member m)
             return getId() != null && Objects.equals(getId(), m.getId());
         return false;
     }
-
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -25,7 +25,7 @@ public class TeamController {
     public ResponseEntity<TeamResponse> createTeam(@Login Long memberId,
                                                    @Valid @RequestBody TeamCreateRequest request) {
         Team team = teamService.createTeam(memberId,
-                new TeamCreateDto(request.name(), request.startTime(), request.endTime(), request.feedbackType()));
+                new TeamCreateDto(request));
 
         return new ResponseEntity<>(new TeamResponse(team), HttpStatus.CREATED);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -1,0 +1,32 @@
+package com.feedhanjum.back_end.team.controller;
+
+import com.feedhanjum.back_end.auth.infra.Login;
+import com.feedhanjum.back_end.team.controller.dto.TeamCreateRequest;
+import com.feedhanjum.back_end.team.controller.dto.TeamResponse;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.service.TeamService;
+import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/team")
+@RequiredArgsConstructor
+public class TeamController {
+    private final TeamService teamService;
+
+    @PostMapping("/create")
+    public ResponseEntity<TeamResponse> createTeam(@Login Long memberId,
+                                                   @Valid @RequestBody TeamCreateRequest request) {
+        Team team = teamService.createTeam(memberId,
+                new TeamCreateDto(request.name(), request.startTime(), request.endTime(), request.feedbackType()));
+
+        return new ResponseEntity<>(new TeamResponse(team), HttpStatus.CREATED);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamCreateRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamCreateRequest.java
@@ -1,0 +1,13 @@
+package com.feedhanjum.back_end.team.controller.dto;
+
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+
+import java.time.LocalDateTime;
+
+public record TeamCreateRequest(
+        String name,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        FeedbackType feedbackType
+) {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamResponse.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamResponse.java
@@ -1,0 +1,26 @@
+package com.feedhanjum.back_end.team.controller.dto;
+
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.team.domain.Team;
+
+import java.time.LocalDateTime;
+
+public record TeamResponse(
+        Long id,
+        String name,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        FeedbackType feedbackType,
+        MemberDto leader
+) {
+    public TeamResponse(Team team) {
+        this(
+                team.getId(),
+                team.getName(),
+                team.getStartTime(),
+                team.getEndTime(),
+                team.getFeedbackType(),
+                new MemberDto(team.getLeader()));
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -1,0 +1,40 @@
+package com.feedhanjum.back_end.team.service;
+
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.domain.TeamMember;
+import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
+import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * @throws IllegalArgumentException 프로젝트 기간의 시작일이 종료일보다 앞서지 않을 경우
+     * @throws EntityNotFoundException  팀 생성 요청한 리더가 존재하지 않을 경우
+     */
+    @Transactional
+    public Team createTeam(Long leaderId, TeamCreateDto teamCreateDto) {
+        if (!teamCreateDto.startTime().isBefore(teamCreateDto.endTime())) {
+            throw new IllegalArgumentException("프로젝트 시작 시간이 종료 시간보다 앞서야 합니다.");
+        }
+        Member leader = memberRepository.findById(leaderId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        Team team = new Team(teamCreateDto.teamName(), leader, teamCreateDto.startTime(), teamCreateDto.endTime(), teamCreateDto.feedbackType());
+        teamRepository.save(team);
+
+        TeamMember teamMember = new TeamMember(team, leader);
+        teamMemberRepository.save(teamMember);
+        return team;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/dto/TeamCreateDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/dto/TeamCreateDto.java
@@ -1,0 +1,13 @@
+package com.feedhanjum.back_end.team.service.dto;
+
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+
+import java.time.LocalDateTime;
+
+public record TeamCreateDto(
+        String teamName,
+        LocalDateTime startTime,
+        LocalDateTime endTime,
+        FeedbackType feedbackType
+) {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/dto/TeamCreateDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/dto/TeamCreateDto.java
@@ -1,6 +1,7 @@
 package com.feedhanjum.back_end.team.service.dto;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.team.controller.dto.TeamCreateRequest;
 
 import java.time.LocalDateTime;
 
@@ -10,4 +11,7 @@ public record TeamCreateDto(
         LocalDateTime endTime,
         FeedbackType feedbackType
 ) {
+    public TeamCreateDto(TeamCreateRequest request) {
+        this(request.name(), request.startTime(), request.endTime(), request.feedbackType());
+    }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
@@ -1,0 +1,57 @@
+package com.feedhanjum.back_end.team.controller;
+
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.team.controller.dto.TeamCreateRequest;
+import com.feedhanjum.back_end.team.controller.dto.TeamResponse;
+import com.feedhanjum.back_end.team.service.TeamService;
+import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TeamControllerTest {
+
+    @Mock
+    private TeamService teamService;
+    @InjectMocks
+    private TeamController teamController;
+
+
+    @Test
+    @DisplayName("팀 생성 컨트롤러 테스트")
+    void createTeam_팀생성_컨트롤러() {
+        //given
+        Long memberId = 1L;
+        LocalDateTime startTime = LocalDateTime.now().plusDays(1);
+        LocalDateTime endTime = LocalDateTime.now().plusDays(10);
+        TeamCreateRequest request = new TeamCreateRequest("haha", startTime,
+                endTime, FeedbackType.ANONYMOUS);
+        TeamCreateDto teamCreateDto = new TeamCreateDto(request);
+        TeamResponse teamResponse = new TeamResponse(null, "haha", startTime,
+                endTime, FeedbackType.ANONYMOUS, new MemberDto(new com.feedhanjum.back_end.member.domain.Member("haha", "haha@hoho", null)));
+        when(teamService.createTeam(memberId, teamCreateDto))
+                .thenReturn(new com.feedhanjum.back_end.team.domain.Team("haha", new com.feedhanjum.back_end.member.domain.Member("haha", "haha@hoho", null),
+                        request.startTime(), request.endTime(), request.feedbackType()));
+
+        //when
+        ResponseEntity<TeamResponse> response = teamController.createTeam(memberId, request);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isEqualTo(teamResponse);
+    }
+
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
@@ -1,0 +1,88 @@
+package com.feedhanjum.back_end.team.service;
+
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.domain.ProfileImage;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.domain.TeamMember;
+import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
+import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class TeamServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @Mock
+    private TeamMemberRepository teamMemberRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private TeamService teamService;
+
+    @Test
+    @DisplayName("프로젝트 기간이 올바른 경우 팀 생성 성공")
+    void createTeam_팀생성() {
+        //given
+        Long userId = 1L;
+        String teamName = "haha";
+        LocalDateTime startTime = LocalDateTime.now().plusDays(1);
+        LocalDateTime endTime = LocalDateTime.now().plusDays(10);
+        FeedbackType feedbackType = FeedbackType.ANONYMOUS;
+        Member leader = new Member("haha", "haha@hoho", new ProfileImage("blue", "image1"));
+
+        ReflectionTestUtils.setField(leader, "id", userId);
+
+        when(memberRepository.findById(userId)).thenReturn(Optional.of(leader));
+        when(teamRepository.save(any(Team.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(teamMemberRepository.save(any(TeamMember.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        //when
+        Team team = teamService.createTeam(userId, new TeamCreateDto(teamName, startTime, endTime, feedbackType));
+
+        //then
+        assertThat(team.getName()).isEqualTo(teamName);
+        assertThat(team.getLeader()).isEqualTo(leader);
+        assertThat(team.getStartTime()).isEqualTo(startTime);
+        assertThat(team.getEndTime()).isEqualTo(endTime);
+        assertThat(team.getFeedbackType()).isEqualTo(feedbackType);
+    }
+
+    @Test
+    @DisplayName("프로젝트 기간이 올바르지 않을 경우 팀 생성 실패")
+    void createTeam_프로젝트기간오류() {
+        //given
+        Long userId = 1L;
+        String teamName = "haha";
+        LocalDateTime startTime = LocalDateTime.now().plusDays(10);
+        LocalDateTime endTime = LocalDateTime.now().plusDays(1);
+        FeedbackType feedbackType = FeedbackType.ANONYMOUS;
+
+        //when & then
+        assertThatThrownBy(() -> teamService.createTeam(userId, new TeamCreateDto(teamName, startTime, endTime, feedbackType)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("프로젝트 시작 시간이 종료 시간보다 앞서야 합니다.");
+    }
+
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
@@ -2,7 +2,6 @@ package com.feedhanjum.back_end.team.service;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.member.domain.Member;
-import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -23,6 +21,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
@@ -50,9 +49,7 @@ class TeamServiceTest {
         LocalDateTime startTime = LocalDateTime.now().plusDays(1);
         LocalDateTime endTime = LocalDateTime.now().plusDays(10);
         FeedbackType feedbackType = FeedbackType.ANONYMOUS;
-        Member leader = new Member("haha", "haha@hoho", new ProfileImage("blue", "image1"));
-
-        ReflectionTestUtils.setField(leader, "id", userId);
+        Member leader = mock(Member.class);
 
         when(memberRepository.findById(userId)).thenReturn(Optional.of(leader));
         when(teamRepository.save(any(Team.class))).thenAnswer(invocation -> invocation.getArgument(0));


### PR DESCRIPTION
# 관련 이슈
FD-13

# 변경된 점
- [x] MemberController 의 매핑 앞 /api 추가
- [x] 팀 생성 서비스, 컨트롤러 코드 작성
- [x] 팀 생성 서비스, 컨트롤러 테스트 코드 작성
- [x] Member 비교 시, 참조값을 우선 비교하도록 설정
    - id 가 null이라도, 참조값이 같으면 동등한 객체로 봄으로써 테스트 시 편의성 확보

