### PR TITLE
[FD-14] 내가 속한 팀 조회 기능 구현

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/core/config/QuerydslConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.feedhanjum.back_end.core.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -10,10 +10,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/team")
@@ -28,5 +28,14 @@ public class TeamController {
                 new TeamCreateDto(request.name(), request.startTime(), request.endTime(), request.feedbackType()));
 
         return new ResponseEntity<>(new TeamResponse(team), HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamResponse>> getMyTeams(@Login Long memberId) {
+        List<TeamResponse> teams = teamService.getMyTeams(memberId)
+                .stream()
+                .map(TeamResponse::new)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(teams);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamQueryRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamQueryRepository.java
@@ -1,0 +1,25 @@
+package com.feedhanjum.back_end.team.repository;
+
+import com.feedhanjum.back_end.team.domain.Team;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.feedhanjum.back_end.team.domain.QTeam.team;
+import static com.feedhanjum.back_end.team.domain.QTeamMember.teamMember;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Team> findTeamByMemberId(Long memberId) {
+        return jpaQueryFactory.select(team)
+                .from(teamMember)
+                .join(teamMember.team, team).fetchJoin()
+                .where(teamMember.member.id.eq(memberId))
+                .fetch();
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -5,6 +5,7 @@ import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
 import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamQueryRepository;
 import com.feedhanjum.back_end.team.repository.TeamRepository;
 import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
 import jakarta.persistence.EntityNotFoundException;
@@ -12,12 +13,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TeamService {
     private final TeamRepository teamRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
+    private final TeamQueryRepository teamQueryRepository;
 
     /**
      * @throws IllegalArgumentException 프로젝트 기간의 시작일이 종료일보다 앞서지 않을 경우
@@ -36,5 +40,10 @@ public class TeamService {
         TeamMember teamMember = new TeamMember(team, leader);
         teamMemberRepository.save(teamMember);
         return team;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Team> getMyTeams(Long userId) {
+        return teamQueryRepository.findTeamByMemberId(userId);
     }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
@@ -2,8 +2,10 @@ package com.feedhanjum.back_end.team.controller;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.team.controller.dto.TeamCreateRequest;
 import com.feedhanjum.back_end.team.controller.dto.TeamResponse;
+import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.service.TeamService;
 import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -54,4 +57,22 @@ class TeamControllerTest {
         assertThat(response.getBody()).isEqualTo(teamResponse);
     }
 
+    @Test
+    @DisplayName("내 팀 조회 컨트롤러 테스트")
+    void getMyTeams_팀조회_컨트롤러() {
+        //given
+        Long memberId = 1L;
+        Team team = new Team("haha", new Member("haha", "haha@hoho", null), LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(10), FeedbackType.ANONYMOUS);
+        TeamResponse teamResponse = new TeamResponse(team);
+        when(teamService.getMyTeams(memberId)).thenReturn(List.of(team));
+
+        //when
+        ResponseEntity<List<TeamResponse>> response = teamController.getMyTeams(memberId);
+
+        //then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0)).isEqualTo(teamResponse);
+    }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
@@ -2,10 +2,12 @@ package com.feedhanjum.back_end.team.service;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
 import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamQueryRepository;
 import com.feedhanjum.back_end.team.repository.TeamRepository;
 import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +36,9 @@ class TeamServiceTest {
 
     @Mock
     private TeamMemberRepository teamMemberRepository;
+
+    @Mock
+    private TeamQueryRepository teamQueryRepository;
 
     @Mock
     private MemberRepository memberRepository;
@@ -82,4 +88,20 @@ class TeamServiceTest {
                 .hasMessageContaining("프로젝트 시작 시간이 종료 시간보다 앞서야 합니다.");
     }
 
+    @Test
+    @DisplayName("내가 가입한 팀 목록 조회 성공")
+    void getMyTeams_팀조회() {
+        //given
+        Long userId = 1L;
+        Member leader = new Member("haha", "haha@hoho", new ProfileImage("blue", "image1"));
+        Team team = new Team("haha", leader, LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(10), FeedbackType.ANONYMOUS);
+        when(teamQueryRepository.findTeamByMemberId(userId)).thenReturn(List.of(team));
+
+        //when
+        List<Team> result = teamService.getMyTeams(userId);
+
+        //then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(team.getId());
+    }
 }


### PR DESCRIPTION
# 관련 이슈
FD-14

# 변경된 점
- [x] JpaQueryFactory 스프링 빈으로 등록
- [x] 내가 속한 팀 조회를 구현하기 위한 TeamQueryRepository 구현
- [x] 내가 속한 팀 조회 기능의 서비스, 컨트롤러 코드 구현
- [x] 내가 속한 팀 조회 기능의 서비스, 컨트롤러 테스트 코드 구현
