### PR TITLE
[FD-21] 팀원 조회 기능 구현

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/core/exception/ValidationControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/exception/ValidationControllerAdvice.java
@@ -4,7 +4,6 @@ import jakarta.validation.ConstraintViolationException;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -23,9 +22,7 @@ public class ValidationControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();
-        for (FieldError error : e.getBindingResult().getFieldErrors()) {
-            errors.put(error.getField(), error.getDefaultMessage());
-        }
+        e.getBindingResult().getAllErrors().forEach(error -> errors.put(error.getDefaultMessage(), error.getDefaultMessage()));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
@@ -41,5 +38,4 @@ public class ValidationControllerAdvice {
                 errors.put(violation.getPropertyPath().toString(), violation.getMessage()));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
-
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/exception/TeamMembershipNotFoundException.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/exception/TeamMembershipNotFoundException.java
@@ -1,0 +1,7 @@
+package com.feedhanjum.back_end.member.exception;
+
+public class TeamMembershipNotFoundException extends RuntimeException {
+    public TeamMembershipNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/repository/MemberQueryRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/repository/MemberQueryRepository.java
@@ -1,0 +1,26 @@
+package com.feedhanjum.back_end.member.repository;
+
+import com.feedhanjum.back_end.member.domain.Member;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.feedhanjum.back_end.member.domain.QMember.member;
+import static com.feedhanjum.back_end.team.domain.QTeamMember.teamMember;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Member> findMembersByTeamId(Long teamId) {
+        return jpaQueryFactory.select(member)
+                .from(teamMember)
+                .join(teamMember.member, member)
+                .fetchJoin()
+                .where(teamMember.team.id.eq(teamId))
+                .fetch();
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -2,16 +2,23 @@ package com.feedhanjum.back_end.member.service;
 
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
+import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
+import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberQueryRepository memberQueryRepository;
 
     /**
      * @throws EntityNotFoundException 찾으려는 해당 사용자가 없는 경우
@@ -36,5 +43,15 @@ public class MemberService {
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
         loginMember.changeProfile(profileImage);
         return loginMember;
+    }
+
+    /**
+     * @throws TeamMembershipNotFoundException 해당 팀에 속해있지 않은 사용자가 팀원 정보를 획득하려고 할 시
+     */
+    @Transactional(readOnly = true)
+    public List<Member> getMembersByTeam(Long memberId, Long teamId) {
+        if (teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).isEmpty())
+            throw new TeamMembershipNotFoundException("속해있는 팀에 대한 정보만 접근 가능합니다.");
+        return memberQueryRepository.findMembersByTeamId(teamId);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -1,7 +1,10 @@
 package com.feedhanjum.back_end.team.controller;
 
 import com.feedhanjum.back_end.auth.infra.Login;
+import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.member.service.MemberService;
 import com.feedhanjum.back_end.team.controller.dto.TeamCreateRequest;
+import com.feedhanjum.back_end.team.controller.dto.TeamDetailResponse;
 import com.feedhanjum.back_end.team.controller.dto.TeamResponse;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.service.TeamService;
@@ -20,6 +23,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class TeamController {
     private final TeamService teamService;
+    private final MemberService memberService;
 
     @PostMapping("/create")
     public ResponseEntity<TeamResponse> createTeam(@Login Long memberId,
@@ -30,12 +34,35 @@ public class TeamController {
         return new ResponseEntity<>(new TeamResponse(team), HttpStatus.CREATED);
     }
 
-    @GetMapping
+    @GetMapping("/my-teams")
     public ResponseEntity<List<TeamResponse>> getMyTeams(@Login Long memberId) {
         List<TeamResponse> teams = teamService.getMyTeams(memberId)
                 .stream()
                 .map(TeamResponse::new)
                 .collect(Collectors.toList());
         return ResponseEntity.ok(teams);
+    }
+
+    /**
+     * 팀 스페이스 관리 화면에서 쓰일 거 같아서 만들긴 했는데, 확실치 않아 주석 달아둡니다.
+     *
+     * @return 팀 정보 + 속한 회원 정보를 반환
+     */
+    @GetMapping("/{teamId}")
+    public ResponseEntity<TeamDetailResponse> getTeamDetail(@Login Long memberId, @PathVariable Long teamId) {
+        Team team = teamService.getTeam(teamId);
+        List<MemberDto> membersByTeam = memberService.getMembersByTeam(memberId, teamId)
+                .stream().map(MemberDto::new).toList();
+        TeamDetailResponse teamDetailResponse = new TeamDetailResponse();
+        teamDetailResponse.setTeamResponse(new TeamResponse(team));
+        teamDetailResponse.setMembers(membersByTeam);
+        return ResponseEntity.ok(teamDetailResponse);
+    }
+
+    @GetMapping("/{teamId}/members")
+    public ResponseEntity<List<MemberDto>> getTeamMembers(@Login Long memberId, @PathVariable Long teamId) {
+        List<MemberDto> membersByTeam = memberService.getMembersByTeam(memberId, teamId)
+                .stream().map(MemberDto::new).toList();
+        return ResponseEntity.ok(membersByTeam);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamDetailResponse.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamDetailResponse.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.team.controller.dto;
+
+import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TeamDetailResponse {
+    private TeamResponse teamResponse;
+    private List<MemberDto> members;
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamMemberControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamMemberControllerAdvice.java
@@ -1,0 +1,14 @@
+package com.feedhanjum.back_end.team.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class TeamMemberControllerAdvice {
+    @ExceptionHandler(TeamMembershipNotFoundException.class)
+    public ResponseEntity<String> teamMembershipNotFoundException(TeamMembershipNotFoundException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamMembershipNotFoundException.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamMembershipNotFoundException.java
@@ -1,4 +1,4 @@
-package com.feedhanjum.back_end.member.exception;
+package com.feedhanjum.back_end.team.exception;
 
 public class TeamMembershipNotFoundException extends RuntimeException {
     public TeamMembershipNotFoundException(String message) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -43,6 +43,11 @@ public class TeamService {
     }
 
     @Transactional(readOnly = true)
+    public Team getTeam(Long teamId) {
+        return teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("해당 팀을 찾을 수 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
     public List<Team> getMyTeams(Long userId) {
         return teamQueryRepository.findTeamByMemberId(userId);
     }


### PR DESCRIPTION
# 관련 이슈
FD-21

# 변경된 점
- [x] 특정 팀에 속한 팀원 정보를 fetch join 하기 위한 MemberQueryRepository 구현
- [x] 특정 팀의 팀원 정보를 반환하는 API 구현
- [x] 특정 팀의 팀원 정보 + 팀 자체의 정보를 반환하는 API 구현