### PR TITLE
[FD-253] 수시 피드백 작성 시 수시 피드백 요청에서 삭제

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/handler/FrequentFeedbackCreatedEventHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/handler/FrequentFeedbackCreatedEventHandler.java
@@ -1,0 +1,22 @@
+package com.feedhanjum.back_end.feedback.event.handler;
+
+import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
+import com.feedhanjum.back_end.feedback.service.FeedbackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class FrequentFeedbackCreatedEventHandler {
+    private final FeedbackService feedbackService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void deleteFrequentFeedbackRequest(FrequentFeedbackCreatedEvent event) {
+        Long feedbackId = event.getFeedbackId();
+        feedbackService.deleteRelatedFrequentFeedbackRequest(feedbackId);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/FrequentFeedbackRequestRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/FrequentFeedbackRequestRepository.java
@@ -1,13 +1,14 @@
 package com.feedhanjum.back_end.team.repository;
 
+import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.team.domain.FrequentFeedbackRequest;
 import com.feedhanjum.back_end.team.domain.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface FrequentFeedbackRequestRepository extends JpaRepository<FrequentFeedbackRequest, Long> {
-    List<FrequentFeedbackRequest> findByTeamMember(TeamMember teamMember);
+    Optional<FrequentFeedbackRequest> findByTeamMemberAndRequester(TeamMember teamMember, Member requester);
 
     void deleteAllByTeamMember(TeamMember teamMember);
 }


### PR DESCRIPTION
# 연관 이슈
FD-253

# 변경된 점
- 피드백과 연관된 수시 피드백 요청을 삭제하는 기능 추가
- 수시 피드백 작성 이벤트가 발생하면 연관된 수시 피드백 요청 삭제로 연결해주는 이벤트 핸들러 추가
