### PR TITLE
[FD-291] 이벤트 기반 알림 생성 기능

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FeedbackLikedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FeedbackLikedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.feedback.event;
 
-import lombok.Getter;
-
-@Getter
-public class FeedbackLikedEvent {
-    private final Long feedbackId;
-
-    public FeedbackLikedEvent(Long feedbackId) {
-        this.feedbackId = feedbackId;
-    }
+public record FeedbackLikedEvent(Long feedbackId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FeedbackReportCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FeedbackReportCreatedEvent.java
@@ -1,4 +1,9 @@
 package com.feedhanjum.back_end.feedback.event;
 
-public class FeedbackReportCreatedEvent {
+import jakarta.annotation.Nullable;
+
+/**
+ * @param endedTeamId 팀의 종료와 별개로 피드백이 최초로 20개 쌓였을 경우 피드백 리포트가 생성되므로, 이 때 해당 필드가 null이 된다.
+ */
+public record FeedbackReportCreatedEvent(Long receiverId, @Nullable Long endedTeamId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FeedbackReportCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FeedbackReportCreatedEvent.java
@@ -1,0 +1,4 @@
+package com.feedhanjum.back_end.feedback.event;
+
+public class FeedbackReportCreatedEvent {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FrequentFeedbackCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/FrequentFeedbackCreatedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.feedback.event;
 
-import lombok.Getter;
-
-@Getter
-public class FrequentFeedbackCreatedEvent {
-    private final Long feedbackId;
-
-    public FrequentFeedbackCreatedEvent(Long feedbackId) {
-        this.feedbackId = feedbackId;
-    }
+public record FrequentFeedbackCreatedEvent(Long feedbackId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/RegularFeedbackCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/RegularFeedbackCreatedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.feedback.event;
 
-import lombok.Getter;
-
-@Getter
-public class RegularFeedbackCreatedEvent {
-    private final Long feedbackId;
-
-    public RegularFeedbackCreatedEvent(Long feedbackId) {
-        this.feedbackId = feedbackId;
-    }
+public record RegularFeedbackCreatedEvent(Long feedbackId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/handler/FrequentFeedbackCreatedEventHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/event/handler/FrequentFeedbackCreatedEventHandler.java
@@ -16,7 +16,7 @@ public class FrequentFeedbackCreatedEventHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void deleteFrequentFeedbackRequest(FrequentFeedbackCreatedEvent event) {
-        Long feedbackId = event.getFeedbackId();
+        Long feedbackId = event.feedbackId();
         feedbackService.deleteRelatedFrequentFeedbackRequest(feedbackId);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/InAppNotificationController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/InAppNotificationController.java
@@ -2,21 +2,17 @@ package com.feedhanjum.back_end.notification.controller;
 
 import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.notification.controller.dto.MultipleNotificationReadRequest;
-import com.feedhanjum.back_end.notification.controller.dto.UnreadNotificationResponse;
 import com.feedhanjum.back_end.notification.controller.dto.notification.InAppNotificationDto;
 import com.feedhanjum.back_end.notification.service.InAppNotificationService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Objects;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -29,36 +25,20 @@ public class InAppNotificationController {
     @Operation(summary = "알림 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "알림 조회 성공"),
-            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우", content = @Content)
     })
-    @GetMapping(value = "/receiver/{receiverId}", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<InAppNotificationDto>> getNotification(@Login Long loginId, @PathVariable Long receiverId) {
-        if (!Objects.equals(loginId, receiverId)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
+    @GetMapping(produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<InAppNotificationDto>> getNotification(@Login Long receiverId) {
         List<InAppNotificationDto> notifications = inAppNotificationService.getInAppNotifications(receiverId);
         return ResponseEntity.ok(notifications);
     }
 
-    @Operation(summary = "안읽은 알림 존재여부 조회")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "안읽은 알림 존재여부 조회 성공"),
-    })
-    @GetMapping(value = "/receiver/{receiverId}/unread", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<UnreadNotificationResponse> checkUnreadNotification(@PathVariable Long receiverId) {
-        return ResponseEntity.ok().build();
-    }
 
     @Operation(summary = "여러 알림 일괄 읽음 처리")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "알림 읽음 처리 성공"),
-            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우", content = @Content)
     })
-    @PostMapping(value = "/receiver/{receiverId}/mark-as-read", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> readNotifications(@Login Long loginId, @PathVariable Long receiverId, @Valid @RequestBody MultipleNotificationReadRequest readRequest) {
-        if (!Objects.equals(loginId, receiverId)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
+    @PostMapping(value = "/mark-as-read", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> readNotifications(@Login Long receiverId, @Valid @RequestBody MultipleNotificationReadRequest readRequest) {
         inAppNotificationService.readInAppNotifications(receiverId, readRequest.notificationIds());
         return ResponseEntity.noContent().build();
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/InAppNotificationController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/InAppNotificationController.java
@@ -1,12 +1,15 @@
 package com.feedhanjum.back_end.notification.controller;
 
 import com.feedhanjum.back_end.auth.infra.Login;
+import com.feedhanjum.back_end.notification.controller.dto.MultipleNotificationReadRequest;
 import com.feedhanjum.back_end.notification.controller.dto.UnreadNotificationResponse;
 import com.feedhanjum.back_end.notification.controller.dto.notification.InAppNotificationDto;
 import com.feedhanjum.back_end.notification.service.InAppNotificationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +29,7 @@ public class InAppNotificationController {
     @Operation(summary = "알림 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "알림 조회 성공"),
-            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우")
+            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우", content = @Content)
     })
     @GetMapping(value = "/receiver/{receiverId}", produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<List<InAppNotificationDto>> getNotification(@Login Long loginId, @PathVariable Long receiverId) {
@@ -46,13 +49,18 @@ public class InAppNotificationController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "알림 읽음 처리")
+    @Operation(summary = "여러 알림 일괄 읽음 처리")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "알림 읽음 처리 성공"),
+            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우", content = @Content)
     })
-    @PutMapping(value = "/{notificationId}/read", produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> readNotification(@PathVariable Long notificationId) {
-        return ResponseEntity.ok().build();
+    @PostMapping(value = "/receiver/{receiverId}/mark-as-read", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> readNotifications(@Login Long loginId, @PathVariable Long receiverId, @Valid @RequestBody MultipleNotificationReadRequest readRequest) {
+        if (!Objects.equals(loginId, receiverId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        inAppNotificationService.readInAppNotifications(receiverId, readRequest.notificationIds());
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/MultipleNotificationReadRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/MultipleNotificationReadRequest.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.notification.controller.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "여러 알림 읽음 처리 요청")
+public record MultipleNotificationReadRequest(
+        @Schema(description = "읽음 처리할 알림들의 ID")
+        List<Long> notificationIds
+) {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReceiveNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReceiveNotificationDto.java
@@ -15,9 +15,9 @@ public class FeedbackReceiveNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.FEEDBACK_RECEIVE)
     private final String type = NotificationType.FEEDBACK_RECEIVE;
     @Schema(description = "보낸 사람 이름")
-    private String senderName;
+    private final String senderName;
     @Schema(description = "팀 이름")
-    private String teamName;
+    private final String teamName;
 
     @Builder
     public FeedbackReceiveNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String senderName, String teamName) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReportCreateNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReportCreateNotificationDto.java
@@ -3,6 +3,7 @@ package com.feedhanjum.back_end.notification.controller.dto.notification;
 import com.feedhanjum.back_end.notification.domain.FeedbackReportCreateNotification;
 import com.feedhanjum.back_end.notification.domain.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,13 +14,14 @@ import java.time.LocalDateTime;
 public class FeedbackReportCreateNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.FEEDBACK_REPORT_CREATE)
     private final String type = NotificationType.FEEDBACK_REPORT_CREATE;
-    @Schema(description = "종료된 팀 이름")
+    @Schema(description = "종료된 팀 이름. 처음으로 피드백 20개가 쌓였을 경우 팀과 별개로 피드백 리포트가 생성되므로, 이 때 본 필드는 null이 됨")
+    @Nullable
     private final String teamName;
     @Schema(description = "받는 사람 이름")
     private final String receiverName;
 
     @Builder
-    public FeedbackReportCreateNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String teamName, String receiverName) {
+    public FeedbackReportCreateNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, @Nullable String teamName, String receiverName) {
         super(notificationId, receiverId, createdAt, isRead);
         this.teamName = teamName;
         this.receiverName = receiverName;

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReportCreateNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReportCreateNotificationDto.java
@@ -14,9 +14,9 @@ public class FeedbackReportCreateNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.FEEDBACK_REPORT_CREATE)
     private final String type = NotificationType.FEEDBACK_REPORT_CREATE;
     @Schema(description = "종료된 팀 이름")
-    private String teamName;
+    private final String teamName;
     @Schema(description = "받는 사람 이름")
-    private String receiverName;
+    private final String receiverName;
 
     @Builder
     public FeedbackReportCreateNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String teamName, String receiverName) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FrequentFeedbackRequestNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FrequentFeedbackRequestNotificationDto.java
@@ -14,9 +14,9 @@ public class FrequentFeedbackRequestNotificationDto extends InAppNotificationDto
     @Schema(description = "알림 타입", allowableValues = NotificationType.FREQUENT_FEEDBACK_REQUEST)
     private final String type = NotificationType.FREQUENT_FEEDBACK_REQUEST;
     @Schema(description = "요청자 이름")
-    private String senderName;
+    private final String senderName;
     @Schema(description = "팀 id")
-    private Long teamId;
+    private final Long teamId;
 
     @Builder
     public FrequentFeedbackRequestNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String senderName, Long teamId) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/HeartReactionNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/HeartReactionNotificationDto.java
@@ -14,9 +14,9 @@ public class HeartReactionNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.HEART_REACTION)
     private final String type = NotificationType.HEART_REACTION;
     @Schema(description = "보낸 사람 이름")
-    private String senderName;
+    private final String senderName;
     @Schema(description = "팀 이름")
-    private String teamName;
+    private final String teamName;
 
     @Builder
     public HeartReactionNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String senderName, String teamName) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/InAppNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/InAppNotificationDto.java
@@ -27,13 +27,13 @@ import java.time.LocalDateTime;
 @Getter
 public abstract class InAppNotificationDto {
     @Schema(description = "알림 ID")
-    protected Long notificationId;
+    protected final Long notificationId;
     @Schema(description = "받는 사람 ID")
-    protected Long receiverId;
+    protected final Long receiverId;
     @Schema(description = "알림 생성 시간")
-    protected LocalDateTime createdAt;
+    protected final LocalDateTime createdAt;
     @Schema(description = "읽음 여부")
-    private boolean isRead;
+    protected final boolean isRead;
 
     protected InAppNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead) {
         this.notificationId = notificationId;

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/RegularFeedbackRequestNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/RegularFeedbackRequestNotificationDto.java
@@ -15,11 +15,11 @@ public class RegularFeedbackRequestNotificationDto extends InAppNotificationDto 
     @Schema(description = "알림 타입", allowableValues = NotificationType.REGULAR_FEEDBACK_REQUEST)
     private final String type = NotificationType.REGULAR_FEEDBACK_REQUEST;
     @Schema(description = "연관된 일정 이름")
-    private String scheduleName;
+    private final String scheduleName;
     @Schema(description = "연관된 일정 ID")
-    private Long scheduleId;
+    private final Long scheduleId;
     @Schema(description = "연관된 일정이 속한 팀 ID")
-    private Long teamId;
+    private final Long teamId;
 
     @Builder
     public RegularFeedbackRequestNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String scheduleName, Long scheduleId, Long teamId) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/ScheduleCreateNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/ScheduleCreateNotificationDto.java
@@ -14,11 +14,11 @@ public class ScheduleCreateNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.SCHEDULE_CREATE)
     private final String type = NotificationType.SCHEDULE_CREATE;
     @Schema(description = "생성된 일정이 속한 팀 이름")
-    private String teamName;
+    private final String teamName;
     @Schema(description = "생성된 일정의 날짜")
-    private LocalDateTime scheduleDate;
-    @Schema(description = "생성된 일정의 ID")
-    private Long teamId;
+    private final LocalDateTime scheduleDate;
+    @Schema(description = "생성된 일정의 팀 ID")
+    private final Long teamId;
 
     @Builder
     public ScheduleCreateNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String teamName, LocalDateTime scheduleDate, Long teamId) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/TeamLeaderChangeNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/TeamLeaderChangeNotificationDto.java
@@ -14,9 +14,9 @@ public class TeamLeaderChangeNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.TEAM_LEADER_CHANGE)
     private final String type = NotificationType.TEAM_LEADER_CHANGE;
     @Schema(description = "팀장을 맡게 된 팀 이름")
-    private String teamName;
+    private final String teamName;
     @Schema(description = "팀장을 맡게 된 팀 ID")
-    private Long teamId;
+    private final Long teamId;
 
     @Builder
     public TeamLeaderChangeNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String teamName, Long teamId) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/UnreadFeedbackExistNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/UnreadFeedbackExistNotificationDto.java
@@ -14,11 +14,11 @@ public class UnreadFeedbackExistNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.UNREAD_FEEDBACK_EXIST)
     private final String type = NotificationType.UNREAD_FEEDBACK_EXIST;
     @Schema(description = "미확인 피드백의 발송자 이름")
-    private String senderName;
+    private final String senderName;
     @Schema(description = "미확인 피드백의 팀 이름")
-    private String teamName;
+    private final String teamName;
     @Schema(description = "미확인 피드백의 팀 ID")
-    private Long teamId;
+    private final Long teamId;
 
     @Builder
     public UnreadFeedbackExistNotificationDto(Long notificationId, Long receiverId, LocalDateTime createdAt, boolean isRead, String senderName, String teamName, Long teamId) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReceiveNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReceiveNotification.java
@@ -15,10 +15,12 @@ import lombok.NoArgsConstructor;
 public class FeedbackReceiveNotification extends InAppNotification {
     private String senderName;
     private String teamName;
+    private Long teamId;
 
     public FeedbackReceiveNotification(Feedback receivedFeedback) {
-        super(receivedFeedback.getReceiver());
+        super(receivedFeedback.getReceiver().getId());
         this.senderName = receivedFeedback.getSender().getName();
         this.teamName = receivedFeedback.getTeam().getName();
+        this.teamId = receivedFeedback.getTeam().getId();
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReportCreateNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReportCreateNotification.java
@@ -19,7 +19,7 @@ public class FeedbackReportCreateNotification extends InAppNotification {
     private String receiverName;
 
     public FeedbackReportCreateNotification(Member receiver, @Nullable Team team) {
-        super(receiver);
+        super(receiver.getId());
         if (team != null)
             teamName = team.getName();
         else

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReportCreateNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReportCreateNotification.java
@@ -2,6 +2,7 @@ package com.feedhanjum.back_end.notification.domain;
 
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.team.domain.Team;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -13,12 +14,16 @@ import lombok.NoArgsConstructor;
 @Entity
 @DiscriminatorValue(NotificationType.FEEDBACK_REPORT_CREATE)
 public class FeedbackReportCreateNotification extends InAppNotification {
+    @Nullable
     private String teamName;
     private String receiverName;
 
-    public FeedbackReportCreateNotification(Member receiver, Team team) {
+    public FeedbackReportCreateNotification(Member receiver, @Nullable Team team) {
         super(receiver);
-        this.teamName = team.getName();
+        if (team != null)
+            teamName = team.getName();
+        else
+            teamName = null;
         this.receiverName = receiver.getName();
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FrequentFeedbackRequestNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FrequentFeedbackRequestNotification.java
@@ -16,7 +16,7 @@ public class FrequentFeedbackRequestNotification extends InAppNotification {
     private Long teamId;
 
     public FrequentFeedbackRequestNotification(FrequentFeedbackRequest request) {
-        super(request.getTeamMember().getMember());
+        super(request.getTeamMember().getMember().getId());
         this.senderName = request.getRequester().getName();
         this.teamId = request.getTeamMember().getTeam().getId();
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/HeartReactionNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/HeartReactionNotification.java
@@ -16,7 +16,7 @@ public class HeartReactionNotification extends InAppNotification {
     private String teamName;
 
     public HeartReactionNotification(Feedback feedback) {
-        super(feedback.getReceiver());
+        super(feedback.getReceiver().getId());
         this.senderName = feedback.getSender().getName();
         this.teamName = feedback.getTeam().getName();
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
@@ -31,9 +31,9 @@ public class InAppNotification {
     @Column(name = "type", nullable = false, updatable = false, insertable = false)
     protected String type;
 
-    protected InAppNotification(Member receiver) {
+    protected InAppNotification(Long receiverId) {
         this.id = null;
-        this.receiverId = receiver.getId();
+        this.receiverId = receiverId;
         this.createdAt = LocalDateTime.now();
         this.isRead = false;
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
@@ -37,4 +37,15 @@ public class InAppNotification {
         this.createdAt = LocalDateTime.now();
         this.isRead = false;
     }
+
+    public void read(Member notificationReceiver) {
+        if (!isReceiver(notificationReceiver)) {
+            throw new SecurityException("알림을 읽을 권한이 없습니다");
+        }
+        this.isRead = true;
+    }
+
+    private boolean isReceiver(Member member) {
+        return getReceiverId().equals(member.getId());
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/RegularFeedbackRequestNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/RegularFeedbackRequestNotification.java
@@ -1,7 +1,8 @@
 package com.feedhanjum.back_end.notification.domain;
 
 
-import com.feedhanjum.back_end.schedule.domain.RegularFeedbackRequest;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.schedule.domain.Schedule;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -17,10 +18,10 @@ public class RegularFeedbackRequestNotification extends InAppNotification {
     private Long scheduleId;
     private Long teamId;
 
-    public RegularFeedbackRequestNotification(RegularFeedbackRequest request) {
-        super(request.getScheduleMember().getMember());
-        this.scheduleName = request.getScheduleMember().getSchedule().getName();
-        this.scheduleId = request.getScheduleMember().getSchedule().getId();
-        this.teamId = request.getScheduleMember().getSchedule().getTeam().getId();
+    public RegularFeedbackRequestNotification(Member receiver, Schedule schedule) {
+        super(receiver);
+        this.scheduleName = schedule.getName();
+        this.scheduleId = schedule.getId();
+        this.teamId = schedule.getTeam().getId();
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/RegularFeedbackRequestNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/RegularFeedbackRequestNotification.java
@@ -19,7 +19,7 @@ public class RegularFeedbackRequestNotification extends InAppNotification {
     private Long teamId;
 
     public RegularFeedbackRequestNotification(Member receiver, Schedule schedule) {
-        super(receiver);
+        super(receiver.getId());
         this.scheduleName = schedule.getName();
         this.scheduleId = schedule.getId();
         this.teamId = schedule.getTeam().getId();

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/RegularFeedbackRequestNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/RegularFeedbackRequestNotification.java
@@ -20,7 +20,7 @@ public class RegularFeedbackRequestNotification extends InAppNotification {
     public RegularFeedbackRequestNotification(RegularFeedbackRequest request) {
         super(request.getScheduleMember().getMember());
         this.scheduleName = request.getScheduleMember().getSchedule().getName();
-        this.scheduleId = request.getScheduleMember().getId();
+        this.scheduleId = request.getScheduleMember().getSchedule().getId();
         this.teamId = request.getScheduleMember().getSchedule().getTeam().getId();
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/ScheduleCreateNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/ScheduleCreateNotification.java
@@ -20,7 +20,7 @@ public class ScheduleCreateNotification extends InAppNotification {
     private Long teamId;
 
     public ScheduleCreateNotification(Member receiver, Schedule schedule) {
-        super(receiver);
+        super(receiver.getId());
         this.teamName = schedule.getTeam().getName();
         this.scheduleDate = schedule.getStartTime().toLocalDate().atStartOfDay();
         this.teamId = schedule.getTeam().getId();

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/TeamLeaderChangeNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/TeamLeaderChangeNotification.java
@@ -16,7 +16,7 @@ public class TeamLeaderChangeNotification extends InAppNotification {
     private Long teamId;
 
     public TeamLeaderChangeNotification(Team team) {
-        super(team.getLeader());
+        super(team.getLeader().getId());
         this.teamName = team.getName();
         this.teamId = team.getId();
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/UnreadFeedbackExistNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/UnreadFeedbackExistNotification.java
@@ -1,7 +1,5 @@
 package com.feedhanjum.back_end.notification.domain;
 
-import com.feedhanjum.back_end.member.domain.Member;
-import com.feedhanjum.back_end.team.domain.Team;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -17,10 +15,10 @@ public class UnreadFeedbackExistNotification extends InAppNotification {
     private String teamName;
     private Long teamId;
 
-    public UnreadFeedbackExistNotification(Member receiver, Team team, FeedbackReceiveNotification notification) {
-        super(receiver);
+    public UnreadFeedbackExistNotification(FeedbackReceiveNotification notification) {
+        super(notification.getReceiverId());
         this.senderName = notification.getSenderName();
         this.teamName = notification.getTeamName();
-        this.teamId = team.getId();
+        this.teamId = notification.getTeamId();
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/FeedbackReceiveNotificationUnreadEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/FeedbackReceiveNotificationUnreadEvent.java
@@ -1,0 +1,4 @@
+package com.feedhanjum.back_end.notification.event;
+
+public record FeedbackReceiveNotificationUnreadEvent(Long notificationId) {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/InAppNotificationCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/InAppNotificationCreatedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.notification.event;
 
-import lombok.Getter;
-
-@Getter
-public class InAppNotificationCreatedEvent {
-    private final Long notificationId;
-
-    public InAppNotificationCreatedEvent(Long notificationId) {
-        this.notificationId = notificationId;
-    }
+public record InAppNotificationCreatedEvent(Long notificationId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/InAppNotificationCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/InAppNotificationCreatedEvent.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.notification.event;
+
+import lombok.Getter;
+
+@Getter
+public class InAppNotificationCreatedEvent {
+    private final Long notificationId;
+
+    public InAppNotificationCreatedEvent(Long notificationId) {
+        this.notificationId = notificationId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FeedbackLikedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FeedbackLikedHandler.java
@@ -1,0 +1,21 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+import com.feedhanjum.back_end.feedback.event.FeedbackLikedEvent;
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class FeedbackLikedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(FeedbackLikedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FeedbackReceiveNotificationUnreadHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FeedbackReceiveNotificationUnreadHandler.java
@@ -1,0 +1,22 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+import com.feedhanjum.back_end.notification.event.FeedbackReceiveNotificationUnreadEvent;
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class FeedbackReceiveNotificationUnreadHandler {
+
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(FeedbackReceiveNotificationUnreadEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FeedbackReportCreatedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FeedbackReportCreatedHandler.java
@@ -1,0 +1,21 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+import com.feedhanjum.back_end.feedback.event.FeedbackReportCreatedEvent;
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class FeedbackReportCreatedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(FeedbackReportCreatedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FrequentFeedbackCreatedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FrequentFeedbackCreatedHandler.java
@@ -1,0 +1,23 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+
+import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class FrequentFeedbackCreatedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(FrequentFeedbackCreatedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FrequentFeedbackRequestCreatedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/FrequentFeedbackRequestCreatedHandler.java
@@ -1,0 +1,21 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import com.feedhanjum.back_end.team.event.FrequentFeedbackRequestCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class FrequentFeedbackRequestCreatedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(FrequentFeedbackRequestCreatedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/RegularFeedbackCreatedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/RegularFeedbackCreatedHandler.java
@@ -1,0 +1,23 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+
+import com.feedhanjum.back_end.feedback.event.RegularFeedbackCreatedEvent;
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class RegularFeedbackCreatedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(RegularFeedbackCreatedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/RegularFeedbackRequestCreatedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/RegularFeedbackRequestCreatedHandler.java
@@ -1,0 +1,21 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import com.feedhanjum.back_end.schedule.event.RegularFeedbackRequestCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class RegularFeedbackRequestCreatedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(RegularFeedbackRequestCreatedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/ScheduleCreatedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/ScheduleCreatedHandler.java
@@ -1,0 +1,21 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class ScheduleCreatedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(ScheduleCreatedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/TeamLeaderChangedHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/event/handler/TeamLeaderChangedHandler.java
@@ -1,0 +1,21 @@
+package com.feedhanjum.back_end.notification.event.handler;
+
+import com.feedhanjum.back_end.notification.service.InAppNotificationService;
+import com.feedhanjum.back_end.team.event.TeamLeaderChangedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@RequiredArgsConstructor
+@Component
+public class TeamLeaderChangedHandler {
+    private final InAppNotificationService inAppNotificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(TeamLeaderChangedEvent event) {
+        inAppNotificationService.createNotification(event);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/repository/InAppNotificationRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/repository/InAppNotificationRepository.java
@@ -4,4 +4,5 @@ import com.feedhanjum.back_end.notification.domain.InAppNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InAppNotificationRepository extends JpaRepository<InAppNotification, Long> {
+    void removeAllByReceiverIdAndTypeAndIdLessThanEqual(Long receiverId,String type, Long id);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
@@ -1,11 +1,31 @@
 package com.feedhanjum.back_end.notification.service;
 
+import com.feedhanjum.back_end.event.EventPublisher;
+import com.feedhanjum.back_end.feedback.domain.Feedback;
+import com.feedhanjum.back_end.feedback.event.FeedbackLikedEvent;
+import com.feedhanjum.back_end.feedback.event.FeedbackReportCreatedEvent;
+import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
+import com.feedhanjum.back_end.feedback.event.RegularFeedbackCreatedEvent;
+import com.feedhanjum.back_end.feedback.repository.FeedbackRepository;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.notification.controller.dto.notification.InAppNotificationDto;
-import com.feedhanjum.back_end.notification.domain.InAppNotification;
+import com.feedhanjum.back_end.notification.domain.*;
+import com.feedhanjum.back_end.notification.event.InAppNotificationCreatedEvent;
 import com.feedhanjum.back_end.notification.repository.InAppNotificationQueryRepository;
 import com.feedhanjum.back_end.notification.repository.InAppNotificationRepository;
+import com.feedhanjum.back_end.schedule.domain.Schedule;
+import com.feedhanjum.back_end.schedule.event.RegularFeedbackRequestCreatedEvent;
+import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
+import com.feedhanjum.back_end.schedule.repository.ScheduleRepository;
+import com.feedhanjum.back_end.team.domain.FrequentFeedbackRequest;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.domain.TeamMember;
+import com.feedhanjum.back_end.team.event.FrequentFeedbackRequestCreatedEvent;
+import com.feedhanjum.back_end.team.event.TeamLeaderChangedEvent;
+import com.feedhanjum.back_end.team.repository.FrequentFeedbackRequestRepository;
+import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +39,12 @@ public class InAppNotificationService {
     private final InAppNotificationRepository inAppNotificationRepository;
     private final InAppNotificationQueryRepository inAppNotificationQueryRepository;
     private final MemberRepository memberRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final EventPublisher eventPublisher;
+    private final FrequentFeedbackRequestRepository frequentFeedbackRequestRepository;
+    private final FeedbackRepository feedbackRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
 
 
     @Transactional(readOnly = true)
@@ -39,4 +65,112 @@ public class InAppNotificationService {
         }
     }
 
+    @Transactional
+    public void createNotification(FrequentFeedbackRequestCreatedEvent event) {
+        Long feedbackRequestId = event.frequentFeedbackRequestId();
+
+        FrequentFeedbackRequest request = frequentFeedbackRequestRepository.findById(feedbackRequestId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        InAppNotification notification = new FrequentFeedbackRequestNotification(request);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+    }
+
+    @Transactional
+    public void createNotification(RegularFeedbackRequestCreatedEvent event) {
+        Long receiverId = event.receiverId();
+        Long scheduleId = event.scheduleId();
+
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(EntityNotFoundException::new);
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        InAppNotification notification = new RegularFeedbackRequestNotification(receiver, schedule);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+    }
+
+    @Transactional
+    public void createNotification(FeedbackLikedEvent event) {
+        Long feedbackId = event.feedbackId();
+
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        InAppNotification notification = new HeartReactionNotification(feedback);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+    }
+
+    @Transactional
+    public void createNotification(FrequentFeedbackCreatedEvent event) {
+        Long feedbackId = event.feedbackId();
+
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        InAppNotification notification = new FeedbackReceiveNotification(feedback);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+    }
+
+    @Transactional
+    public void createNotification(RegularFeedbackCreatedEvent event) {
+        Long feedbackId = event.feedbackId();
+
+        Feedback feedback = feedbackRepository.findById(feedbackId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        InAppNotification notification = new FeedbackReceiveNotification(feedback);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+    }
+
+    @Transactional
+    public void createNotification(FeedbackReportCreatedEvent event) {
+        Long receiverId = event.receiverId();
+        Long endedTeamId = event.endedTeamId();
+
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(EntityNotFoundException::new);
+        Team team = null;
+        if (endedTeamId != null)
+            team = teamRepository.findById(endedTeamId)
+                    .orElseThrow(EntityNotFoundException::new);
+
+        InAppNotification notification = new FeedbackReportCreateNotification(receiver, team);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+    }
+
+    @Transactional
+    public void createNotification(TeamLeaderChangedEvent event) {
+        Long teamId = event.teamId();
+
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(EntityNotFoundException::new);
+
+
+        InAppNotification notification = new TeamLeaderChangeNotification(team);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+    }
+
+    @Transactional
+    public void createNotification(ScheduleCreatedEvent event) {
+        Long scheduleId = event.scheduleId();
+
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        List<TeamMember> teamMembers = teamMemberRepository.findByTeam(schedule.getTeam());
+        for (TeamMember teamMember : teamMembers) {
+            Member receiver = teamMember.getMember();
+            InAppNotification notification = new ScheduleCreateNotification(receiver, schedule);
+            inAppNotificationRepository.save(notification);
+            eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
+        }
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
@@ -186,6 +186,10 @@ public class InAppNotificationService {
         if (!(feedbackReceiveNotification instanceof FeedbackReceiveNotification)) {
             throw new RuntimeException("피드백 도착 알림이 아닙니다.");
         }
+        // TODO: FeedbackReceiveNotificationUnreadEvent를 생성시키는 배치 작업에서는 receiver별로 안읽은지 24시간이 지난 feedbackReceive 알림이 여러개 있다면 가장 최신의 것만 이벤트로 발행해야 함
+        // 기존에 존재하던 24시간 지난 '피드백 도착' 알림은 삭제
+        inAppNotificationRepository.removeAllByReceiverIdAndTypeAndIdLessThanEqual(feedbackReceiveNotification.getReceiverId(),
+                NotificationType.FEEDBACK_RECEIVE, feedbackReceiveNotification.getId());
 
         InAppNotification notification = new UnreadFeedbackExistNotification((FeedbackReceiveNotification) feedbackReceiveNotification);
         inAppNotificationRepository.save(notification);

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
@@ -11,6 +11,7 @@ import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.notification.controller.dto.notification.InAppNotificationDto;
 import com.feedhanjum.back_end.notification.domain.*;
+import com.feedhanjum.back_end.notification.event.FeedbackReceiveNotificationUnreadEvent;
 import com.feedhanjum.back_end.notification.event.InAppNotificationCreatedEvent;
 import com.feedhanjum.back_end.notification.repository.InAppNotificationQueryRepository;
 import com.feedhanjum.back_end.notification.repository.InAppNotificationRepository;
@@ -172,5 +173,22 @@ public class InAppNotificationService {
             inAppNotificationRepository.save(notification);
             eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
         }
+    }
+
+
+    @Transactional
+    public void createNotification(FeedbackReceiveNotificationUnreadEvent event) {
+        Long notificationId = event.notificationId();
+
+        InAppNotification feedbackReceiveNotification = inAppNotificationRepository.findById(notificationId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        if (!(feedbackReceiveNotification instanceof FeedbackReceiveNotification)) {
+            throw new RuntimeException("피드백 도착 알림이 아닙니다.");
+        }
+
+        InAppNotification notification = new UnreadFeedbackExistNotification((FeedbackReceiveNotification) feedbackReceiveNotification);
+        inAppNotificationRepository.save(notification);
+        eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
@@ -1,10 +1,15 @@
 package com.feedhanjum.back_end.notification.service;
 
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.notification.controller.dto.notification.InAppNotificationDto;
+import com.feedhanjum.back_end.notification.domain.InAppNotification;
 import com.feedhanjum.back_end.notification.repository.InAppNotificationQueryRepository;
 import com.feedhanjum.back_end.notification.repository.InAppNotificationRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -13,10 +18,25 @@ import java.util.List;
 public class InAppNotificationService {
     private final InAppNotificationRepository inAppNotificationRepository;
     private final InAppNotificationQueryRepository inAppNotificationQueryRepository;
+    private final MemberRepository memberRepository;
 
 
+    @Transactional(readOnly = true)
     public List<InAppNotificationDto> getInAppNotifications(Long receiverId) {
         return inAppNotificationQueryRepository.getInAppNotifications(receiverId).stream()
                 .map(InAppNotificationDto::from).toList();
     }
+
+    /**
+     * @throw EntityNotFoundException receiverId에 해당하는 엔티티가 없을 때
+     */
+    @Transactional
+    public void readInAppNotifications(Long receiverId, List<Long> notificationIds) {
+        Member receiver = memberRepository.findById(receiverId).orElseThrow(() -> new EntityNotFoundException("없는 사용자"));
+        List<InAppNotification> notifications = inAppNotificationRepository.findAllById(notificationIds);
+        for (InAppNotification notification : notifications) {
+            notification.read(receiver);
+        }
+    }
+
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/RegularFeedbackRequestCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/RegularFeedbackRequestCreatedEvent.java
@@ -1,14 +1,4 @@
 package com.feedhanjum.back_end.schedule.event;
 
-import lombok.Getter;
-
-@Getter
-public class RegularFeedbackRequestCreatedEvent {
-    private final Long receiverId;
-    private final Long scheduleId;
-
-    public RegularFeedbackRequestCreatedEvent(Long receiverId, Long scheduleId) {
-        this.receiverId = receiverId;
-        this.scheduleId = scheduleId;
-    }
+public record RegularFeedbackRequestCreatedEvent(Long receiverId, Long scheduleId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleCreatedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.schedule.event;
 
-import lombok.Getter;
-
-@Getter
-public class ScheduleCreatedEvent {
-    private final Long scheduleId;
-
-    public ScheduleCreatedEvent(Long scheduleId) {
-        this.scheduleId = scheduleId;
-    }
+public record ScheduleCreatedEvent(Long scheduleId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleCreatedEvent.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.schedule.event;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleCreatedEvent {
+    private final Long scheduleId;
+
+    public ScheduleCreatedEvent(Long scheduleId) {
+        this.scheduleId = scheduleId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleEndedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleEndedEvent.java
@@ -3,10 +3,10 @@ package com.feedhanjum.back_end.schedule.event;
 import lombok.Getter;
 
 @Getter
-public class ScheduleEndEvent {
+public class ScheduleEndedEvent {
     private final Long scheduleId;
 
-    public ScheduleEndEvent(Long scheduleId) {
+    public ScheduleEndedEvent(Long scheduleId) {
         this.scheduleId = scheduleId;
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleEndedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/ScheduleEndedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.schedule.event;
 
-import lombok.Getter;
-
-@Getter
-public class ScheduleEndedEvent {
-    private final Long scheduleId;
-
-    public ScheduleEndedEvent(Long scheduleId) {
-        this.scheduleId = scheduleId;
-    }
+public record ScheduleEndedEvent(Long scheduleId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/ScheduleEndEventListener.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/ScheduleEndEventListener.java
@@ -1,7 +1,7 @@
 package com.feedhanjum.back_end.schedule.event.handler;
 
 import com.feedhanjum.back_end.feedback.service.FeedbackService;
-import com.feedhanjum.back_end.schedule.event.ScheduleEndEvent;
+import com.feedhanjum.back_end.schedule.event.ScheduleEndedEvent;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -17,7 +17,7 @@ public class ScheduleEndEventListener {
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void createRegularFeedbackRequests(ScheduleEndEvent event) {
+    public void createRegularFeedbackRequests(ScheduleEndedEvent event) {
         Long scheduleId = event.getScheduleId();
         feedbackService.createRegularFeedbackRequests(scheduleId);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/ScheduleEndEventListener.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/ScheduleEndEventListener.java
@@ -2,23 +2,21 @@ package com.feedhanjum.back_end.schedule.event.handler;
 
 import com.feedhanjum.back_end.feedback.service.FeedbackService;
 import com.feedhanjum.back_end.schedule.event.ScheduleEndedEvent;
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+@RequiredArgsConstructor
 @Component
 public class ScheduleEndEventListener {
     private final FeedbackService feedbackService;
 
-    public ScheduleEndEventListener(FeedbackService feedbackService) {
-        this.feedbackService = feedbackService;
-    }
-
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void createRegularFeedbackRequests(ScheduleEndedEvent event) {
-        Long scheduleId = event.getScheduleId();
+    public void on(ScheduleEndedEvent event) {
+        Long scheduleId = event.scheduleId();
         feedbackService.createRegularFeedbackRequests(scheduleId);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/event/FrequentFeedbackRequestCreatedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/event/FrequentFeedbackRequestCreatedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.team.event;
 
-import lombok.Getter;
-
-@Getter
-public class FrequentFeedbackRequestCreatedEvent {
-    private final Long frequentFeedbackRequestId;
-
-    public FrequentFeedbackRequestCreatedEvent(Long frequentFeedbackRequestId) {
-        this.frequentFeedbackRequestId = frequentFeedbackRequestId;
-    }
+public record FrequentFeedbackRequestCreatedEvent(Long frequentFeedbackRequestId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamEndedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamEndedEvent.java
@@ -1,0 +1,12 @@
+package com.feedhanjum.back_end.team.event;
+
+import lombok.Getter;
+
+@Getter
+public class TeamEndedEvent {
+    private final Long teamId;
+
+    public TeamEndedEvent(Long teamId) {
+        this.teamId = teamId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamEndedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamEndedEvent.java
@@ -1,12 +1,4 @@
 package com.feedhanjum.back_end.team.event;
 
-import lombok.Getter;
-
-@Getter
-public class TeamEndedEvent {
-    private final Long teamId;
-
-    public TeamEndedEvent(Long teamId) {
-        this.teamId = teamId;
-    }
+public record TeamEndedEvent(Long teamId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamLeaderChangedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamLeaderChangedEvent.java
@@ -1,14 +1,4 @@
 package com.feedhanjum.back_end.team.event;
 
-import lombok.Getter;
-
-@Getter
-public class TeamLeaderChangedEvent {
-    private final Long teamId;
-    private final Long newLeaderId;
-
-    public TeamLeaderChangedEvent(Long teamId, Long newLeaderId) {
-        this.teamId = teamId;
-        this.newLeaderId = newLeaderId;
-    }
+public record TeamLeaderChangedEvent(Long teamId, Long newLeaderId) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamLeaderChangedEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamLeaderChangedEvent.java
@@ -1,0 +1,14 @@
+package com.feedhanjum.back_end.team.event;
+
+import lombok.Getter;
+
+@Getter
+public class TeamLeaderChangedEvent {
+    private final Long teamId;
+    private final Long newLeaderId;
+
+    public TeamLeaderChangedEvent(Long teamId, Long newLeaderId) {
+        this.teamId = teamId;
+        this.newLeaderId = newLeaderId;
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamMemberRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamMemberRepository.java
@@ -1,10 +1,14 @@
 package com.feedhanjum.back_end.team.repository;
 
+import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     Optional<TeamMember> findByMemberIdAndTeamId(Long memberId, Long teamId);
+
+    List<TeamMember> findByTeam(Team team);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
@@ -3,8 +3,5 @@ package com.feedhanjum.back_end.team.repository;
 import com.feedhanjum.back_end.team.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    Optional<Team> findByName(String name);
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -830,9 +830,9 @@ class FeedbackServiceTest {
             ArgumentCaptor<RegularFeedbackRequestCreatedEvent> eventCaptor = ArgumentCaptor.captor();
             verify(eventPublisher, times(3)).publishEvent(eventCaptor.capture());
             List<RegularFeedbackRequestCreatedEvent> events = eventCaptor.getAllValues();
-            assertThat(events).extracting(RegularFeedbackRequestCreatedEvent::getReceiverId)
+            assertThat(events).extracting(RegularFeedbackRequestCreatedEvent::receiverId)
                     .containsExactlyInAnyOrder(member1.getId(), member2.getId(), member3.getId());
-            assertThat(events).extracting(RegularFeedbackRequestCreatedEvent::getScheduleId)
+            assertThat(events).extracting(RegularFeedbackRequestCreatedEvent::scheduleId)
                     .containsOnly(schedule.getId());
         }
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/notification/controller/InAppNotificationControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/notification/controller/InAppNotificationControllerTest.java
@@ -1,5 +1,6 @@
 package com.feedhanjum.back_end.notification.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.feedhanjum.back_end.auth.infra.SessionConst;
@@ -7,6 +8,7 @@ import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.notification.controller.dto.MultipleNotificationReadRequest;
 import com.feedhanjum.back_end.notification.controller.dto.notification.InAppNotificationDto;
 import com.feedhanjum.back_end.notification.domain.FeedbackReportCreateNotification;
 import com.feedhanjum.back_end.notification.domain.InAppNotification;
@@ -23,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
@@ -137,6 +140,56 @@ class InAppNotificationControllerTest {
                     .uri("/api/notification/receiver/{receiverId}", receiver.getId())
                     .session(withLoginUser(notReceiver))
             ).hasStatus(HttpStatus.FORBIDDEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("여러 알림 읽음 처리 테스트")
+    class MarkNotificationAsRead {
+        @Test
+        @DisplayName("성공시 204")
+        void test1() throws JsonProcessingException {
+            Member receiver = member1;
+            Team team = team1;
+            List<InAppNotification> notifications = List.of(
+                    createInAppNotification(receiver, team),
+                    createInAppNotification(receiver, team),
+                    createInAppNotification(receiver, team)
+            );
+            notificationRepository.saveAll(notifications);
+
+            MultipleNotificationReadRequest request = new MultipleNotificationReadRequest(notifications.stream().map(InAppNotification::getId).toList());
+
+            assertThat(mvc.post()
+                    .uri("/api/notification/receiver/{receiverId}/mark-as-read", receiver.getId())
+                    .session(withLoginUser(receiver))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content(mapper.writeValueAsBytes(request))
+            ).hasStatus(HttpStatus.NO_CONTENT);
+
+            List<InAppNotification> all = notificationRepository.findAll();
+            assertThat(all).allMatch(InAppNotification::isRead);
+        }
+
+        @Test
+        @DisplayName("본인이 아닐 시 403")
+        void test2() throws JsonProcessingException {
+            Member receiver = member1;
+            Team team = team1;
+            List<InAppNotification> notifications = List.of(
+                    createInAppNotification(receiver, team)
+            );
+            notificationRepository.saveAll(notifications);
+            MultipleNotificationReadRequest request = new MultipleNotificationReadRequest(notifications.stream().map(InAppNotification::getId).toList());
+            assertThat(mvc.post()
+                    .uri("/api/notification/receiver/{receiverId}/mark-as-read", receiver.getId())
+                    .session(withLoginUser(member2))
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content(mapper.writeValueAsBytes(request))
+            ).hasStatus(HttpStatus.FORBIDDEN);
+
+            List<InAppNotification> all = notificationRepository.findAll();
+            assertThat(all).allMatch(n -> !n.isRead());
         }
     }
 }


### PR DESCRIPTION
# 관련 이슈
FD-291

# 변경된 점
- 이벤트 발생시 이를 기반으로 적절한 알림 생성
  - 수시 피드백 생성됨 이벤트 -> 피드백 도착 알림
  - 정기 피드백 생성됨 이벤트 -> 피드백 도착 알림
  - 피드백 좋아요 이벤트 -> 하트 반응 알림
  - 정기 피드백 요청 생성됨 이벤트 -> 피드백 작성 알림
  - 피드백 리포트 생성됨 이벤트 -> 피드백 리포트 도착 알림
  - 팀장 변경됨 이벤트 -> 팀장 변경 알림
  - 일정 생성됨 이벤트 -> 일정 추가 알림
  - 수시 피드백 요청 생성됨 이벤트 -> 피드백 요청 알림
  - 피드백 도착 알림 미읽음 이벤트 -> 피드백 미확인 알림
- 피드백 미확인 알림 생성 시, 해당 알림 수신자의 '24시간이 넘도록 읽지 않은 피드백 도착 알림' 을 삭제하도록 변경
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
 • Bulk notifications: Users can now mark multiple notifications as read in one action.  
 • Improved notification retrieval for faster, more responsive updates on feedback, scheduling, and team events.  
 • New events introduced for various actions, enhancing notification capabilities.

- **Refactor**  
 • Enhanced backend event handling and data processing for greater performance and reliability, ensuring timely and consistent delivery of in-app notifications.  
 • Transition to Java records for several event classes, simplifying code structure and improving readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->