### PR TITLE
[FD-297]  팀,회원,일정 도메인에 대한 swagger api 기능문서 작성

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/AuthController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/AuthController.java
@@ -37,8 +37,17 @@ public class AuthController {
      * @param request
      * @return 회원 가입 성공 여부
      */
+    @Operation(
+            summary = "회원가입",
+            description = "회원가입을 처리합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원가입을 처리합니다. 동시에 로그인 처리도 수행합니다."),
+            @ApiResponse(responseCode = "401", description = "이메일이 검증되지 않았을 경우", content = @Content),
+            @ApiResponse(responseCode = "409", description = "중복된 이메일이 있을 경우", content = @Content)
+    })
     @PostMapping("/signup")
-    public ResponseEntity<MemberSignupResponse> signup(@Valid @RequestBody MemberSignupRequest request) {
+    public ResponseEntity<MemberSignupResponse> signup(@Valid @RequestBody MemberSignupRequest request, HttpSession session) {
         MemberDetails member = memberMapper.toEntity(request);
         String name = request.name();
         ProfileImage profileImage = request.profileImage();
@@ -46,9 +55,21 @@ public class AuthController {
         MemberDetails savedMember = authService.registerMember(member, name, profileImage);
 
         MemberSignupResponse response = memberMapper.toResponse(savedMember);
+
+        session.setAttribute(SessionConst.MEMBER_ID, member.getId());
+        session.setMaxInactiveInterval(Integer.MAX_VALUE);
+
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
+    @Operation(
+            summary = "로그인",
+            description = "로그인을 처리합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인을 처리합니다. 세션 ID를 쿠키로 등록합니다."),
+            @ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호가 올바르지 않습니다.")
+    })
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request, HttpSession session) {
         MemberDetails member = authService.authenticate(request.email(), request.password());
@@ -61,6 +82,13 @@ public class AuthController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "로그아웃",
+            description = "로그아웃을 처리합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "로그아웃 처리 성공")
+    })
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpServletResponse response, HttpSession session) {
         session.invalidate();

--- a/back-end/src/main/java/com/feedhanjum/back_end/core/exception/ValidationControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/exception/ValidationControllerAdvice.java
@@ -38,4 +38,14 @@ public class ValidationControllerAdvice {
                 errors.put(violation.getPropertyPath().toString(), violation.getMessage()));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e){
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<String> handleSecurityException(SecurityException e){
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackController.java
@@ -12,6 +12,7 @@ import com.feedhanjum.back_end.feedback.service.FeedbackService;
 import com.feedhanjum.back_end.feedback.service.dto.ReceivedFeedbackDto;
 import com.feedhanjum.back_end.feedback.service.dto.SentFeedbackDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
@@ -139,7 +140,7 @@ public class FeedbackController {
     @Operation(summary = "보낸 피드백 조회하기", description = "받은 피드백을 조회힙니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "보낸 피드백 조회 성공", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우")
+            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우", content = @Content)
     })
     @GetMapping("/feedbacks/sender/{senderId}")
     public ResponseEntity<Paged<SentFeedbackDto>> getSentFeedbacks(@Login Long loginId,
@@ -155,7 +156,7 @@ public class FeedbackController {
     @Operation(summary = "받은 피드백 조회하기", description = "받은 피드백을 조회힙니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "보낸 피드백 조회 성공", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우")
+            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우",content = @Content)
     })
     @GetMapping("/feedbacks/receiver/{receiverId}")
     public ResponseEntity<Paged<ReceivedFeedbackDto>> getReceivedFeedbacks(@Login Long loginId,

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -2,8 +2,14 @@ package com.feedhanjum.back_end.member.controller;
 
 import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.member.controller.dto.ProfileChangeRequest;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,21 +21,28 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final MemberService memberService;
 
+    @Operation(summary = "특정 회원 정보 조회", description = "특정 회원의 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회에 성공했을 경우, 해당 회원 정보를 반환합니다."),
+            @ApiResponse(responseCode = "404", description = "해당 회원이 존재하지 않을 경우", content = @Content)
+    })
     @GetMapping("/member/{id}")
     public ResponseEntity<MemberDto> getMemberById(@PathVariable Long id) {
         MemberDto memberDto = new MemberDto(memberService.getMemberById(id));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 
-    @PostMapping("/member/name")
-    public ResponseEntity<MemberDto> changeName(@Login Long memberId, @RequestParam String name) {
-        MemberDto memberDto = new MemberDto(memberService.changeName(memberId, name));
-        return new ResponseEntity<>(memberDto, HttpStatus.OK);
-    }
-
-    @PostMapping("/member/image")
-    public ResponseEntity<MemberDto> changeProfileImage(@Login Long memberId, @RequestBody ProfileImage profileImage) {
-        MemberDto memberDto = new MemberDto(memberService.changeProfileImage(memberId, profileImage));
+    @Operation(summary = "회원의 정보를 변경한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경된 회원 정보를 반환한다. " +
+                    "세션을 통해 받은 회원의 정보를 수정하기 때문에, 다른 회원의 정보를 수정할 수 없다."),
+            @ApiResponse(responseCode = "400", description = "변경할 회원 정보 폼이 잘못됐을 경우, 주로 이름이 제한 범위 밖인 경우")
+    })
+    @PostMapping("/member")
+    public ResponseEntity<MemberDto> changeProfile(@Login Long memberId, @Valid @RequestBody ProfileChangeRequest profileChageRequest) {
+        String name = profileChageRequest.name();
+        ProfileImage profileImage = profileChageRequest.profileImage();
+        MemberDto memberDto = new MemberDto(memberService.changeProfile(memberId, name, profileImage));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -36,7 +36,7 @@ public class MemberController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경된 회원 정보를 반환한다. " +
                     "세션을 통해 받은 회원의 정보를 수정하기 때문에, 다른 회원의 정보를 수정할 수 없다."),
-            @ApiResponse(responseCode = "400", description = "변경할 회원 정보 폼이 잘못됐을 경우, 주로 이름이 제한 범위 밖인 경우")
+            @ApiResponse(responseCode = "400", description = "변경할 회원 정보 폼이 잘못됐을 경우, 주로 이름이 제한 범위 밖인 경우", content = @Content)
     })
     @PostMapping("/member")
     public ResponseEntity<MemberDto> changeProfile(@Login Long memberId, @Valid @RequestBody ProfileChangeRequest profileChageRequest) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/ProfileChangeRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/ProfileChangeRequest.java
@@ -1,0 +1,13 @@
+package com.feedhanjum.back_end.member.controller.dto;
+
+import com.feedhanjum.back_end.member.domain.ProfileImage;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProfileChangeRequest (
+        @NotBlank(message = "활동명을 입력해주세요.")
+        @Size(min = 1, max = 20, message = "활동명은 1자 이상, 20자 이하여야 합니다.")
+        String name,
+        ProfileImage profileImage
+){
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
 import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final TeamMemberRepository teamMemberRepository;
     private final MemberQueryRepository memberQueryRepository;
+    private final TeamRepository teamRepository;
 
     /**
      * @throws EntityNotFoundException 찾으려는 해당 사용자가 없는 경우
@@ -31,16 +33,10 @@ public class MemberService {
     }
 
     @Transactional
-    public Member changeName(Long memberId, String name) {
+    public Member changeProfile(Long memberId, String name, ProfileImage profileImage) {
         // 이거 이럴 일이 없겠지만, 동시성 문제 발생할지 모르니 혹시 몰라서 남겨둡니다.
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
         loginMember.changeName(name);
-        return loginMember;
-    }
-
-    @Transactional
-    public Member changeProfileImage(Long memberId, ProfileImage profileImage) {
-        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RuntimeException("DB 오류"));
         loginMember.changeProfile(profileImage);
         return loginMember;
     }
@@ -50,6 +46,8 @@ public class MemberService {
      */
     @Transactional(readOnly = true)
     public List<Member> getMembersByTeam(Long memberId, Long teamId) {
+        memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+        teamRepository.findById(teamId).orElseThrow(()-> new EntityNotFoundException("해당 팀을 찾을 수 없습니다."));
         if (teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).isEmpty())
             throw new TeamMembershipNotFoundException("속해있는 팀에 대한 정보만 접근 가능합니다.");
         return memberQueryRepository.findMembersByTeamId(teamId);

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/controller/ScheduleController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/controller/ScheduleController.java
@@ -6,6 +6,10 @@ import com.feedhanjum.back_end.schedule.controller.dto.ScheduleRequest;
 import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleNestedDto;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,12 +24,26 @@ import java.util.List;
 public class ScheduleController {
     private final ScheduleService scheduleService;
 
+    @Operation(summary = "새 일정 만들기", description = "해당 팀의 새로운 일정을 만듭니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "일정 만들기 성공. 해당 팀의 모든 팀원을 생성된 일정에 등록함"),
+            @ApiResponse(responseCode = "404", description = "팀 또는 사용자가 존재하지 않을 경우, 혹은 사용자가 해당 팀에 속해있지 않을 경우"),
+            @ApiResponse(responseCode = "400", description = "주어진 양식을 지키지 못했을 경우"),
+            @ApiResponse(responseCode = "409", description = "이미 주어진 시작시간에 일정이 있을 경우")
+
+    })
     @PostMapping("/team/{teamId}/schedule/create")
     public ResponseEntity<Void> createSchedule(@Login Long memberId, @PathVariable Long teamId, @Valid @RequestBody ScheduleRequest request) {
         scheduleService.createSchedule(memberId, teamId, new ScheduleRequestDto(request));
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
-    
+
+    @Operation(summary = "일정 수정하기", description = "특정 일정의 일정/할 일 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "일정/할 일 정보를 수정에 성공함."),
+            @ApiResponse(responseCode = "403", description = "일정을 수정하려는 사용자가 팀장 혹은 일정의 주인이 아닌경우"),
+            @ApiResponse(responseCode = "404", description = "일정, 팀, 혹은 일정과 사용자의 관계를 찾을 수 없는 경우")
+    })
     @PostMapping("/team/{teamId}/schedule/{scheduleId}")
     public ResponseEntity<Void> updateSchedule(@Login Long memberId, 
                                                @PathVariable Long teamId, 
@@ -35,6 +53,11 @@ public class ScheduleController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @Operation(summary = "특정 일정 조회하기", description = "특정 팀의 특정 일정 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일정 조회를 성공함"),
+            @ApiResponse(responseCode = "404", description = "일정을 조회할 권한이 없는 경우 - 일정 숨기기", content = @Content)
+    })
     @GetMapping("/team/{teamId}/schedule/{scheduleId}")
     public ResponseEntity<ScheduleNestedDto> getSchedule(@Login Long memberId,
                                                @PathVariable Long teamId,
@@ -44,6 +67,12 @@ public class ScheduleController {
         return new ResponseEntity<>(schedule, HttpStatus.OK);
     }
 
+    @Operation(summary = "기간 사이의 일정 조회하기", description = "특정 날짜와 날짜 사이에 존재하는 모든 일정을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "기간 사이의 일정 조회에 성공함"),
+            @ApiResponse(responseCode = "404", description = "해당 팀에 가입하지 않은 사용자인 경우", content = @Content),
+            @ApiResponse(responseCode = "400", description = "입력 폼이 잘못된 경우", content = @Content)
+    })
     @GetMapping("/schedules")
     public ResponseEntity<List<ScheduleNestedDto>> getScheduleBetweenDurations(
             @Login Long memberId,
@@ -58,6 +87,11 @@ public class ScheduleController {
         return new ResponseEntity<>(scheduleDurations, HttpStatus.OK);
     }
 
+    @Operation(summary = "팀 메인 화면 일정 조회", description = "특정 팀에 대해서, 메인 화면에 보여줘야 하는 일정을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "메인화면 일정 조회에 성공함"),
+            @ApiResponse(responseCode = "404", description = "해당 팀에 대한 일정 조회 권한이 없는 경우", content = @Content)
+    })
     @GetMapping("/team/{teamId}/schedule")
     public ResponseEntity<ScheduleNestedDto> getNearestSchedule(
             @Login Long memberId,

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/exception/ScheduleControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/exception/ScheduleControllerAdvice.java
@@ -27,5 +27,4 @@ public class ScheduleControllerAdvice {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(e.getMessage());
     }
-    
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
@@ -90,13 +90,11 @@ public class ScheduleService {
         Team team = teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
         Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new EntityNotFoundException("해당 일정을 찾을 수 없습니다."));
-
         validateIsEnded(schedule);
-        changeScheduleInfo(requestDto, schedule, member, team);
-
         ScheduleMember scheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, scheduleId)
-                .orElseThrow(() -> new ScheduleMembershipNotFoundException("해당 사용자와 관련이 없는 일정입니다."));
+                .orElseThrow(() -> new ScheduleMembershipNotFoundException("해당 일정을 찾을 수 없습니다."));
 
+        changeScheduleInfo(requestDto, schedule, member, team);
         scheduleMember.setTodos(requestDto.todos());
     }
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -66,7 +66,7 @@ public class TeamController {
     @Operation(summary = "팀 상세 정보 조회", description = "특정 팀의 상세 정보를 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "해당 팀의 정보 조회에 성공한 경우"),
-            @ApiResponse(responseCode = "404", description = "해당 팀을 조회할 권한이 없는 경우 - 팀 정보 숨김")
+            @ApiResponse(responseCode = "404", description = "해당 팀을 조회할 권한이 없는 경우 - 팀 정보 숨김", content = @Content)
     })
     @GetMapping("/{teamId}")
     public ResponseEntity<TeamDetailResponse> getTeamDetail(@Login Long memberId, @PathVariable Long teamId) {
@@ -82,7 +82,7 @@ public class TeamController {
     @Operation(summary = "팀원 조횐", description = "특정 팀에 존재하는 모든 사용자의 정보를 조회한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공."),
-            @ApiResponse(responseCode = "404", description = "해당 팀에 대한 조회 권한이 없을 경우 - 정보 숨김")
+            @ApiResponse(responseCode = "404", description = "해당 팀에 대한 조회 권한이 없을 경우 - 정보 숨김", content = @Content)
     })
     @GetMapping("/{teamId}/members")
     public ResponseEntity<List<MemberDto>> getTeamMembers(@Login Long memberId, @PathVariable Long teamId) {
@@ -106,8 +106,8 @@ public class TeamController {
     @Operation(summary = "팀 정보 수정", description = "특정 팀의 정보를 수정한다. 탐장만이 사용 가능하다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "해당 팀원을 팀에서 제거하는데 성공"),
-            @ApiResponse(responseCode = "404", description = "해당 팀 또는 팀원을 찾을 수 없는 경우"),
-            @ApiResponse(responseCode = "403", description = "로그인한 사용자가 팀장이 아닌 경우")
+            @ApiResponse(responseCode = "404", description = "해당 팀 또는 팀원을 찾을 수 없는 경우", content = @Content),
+            @ApiResponse(responseCode = "403", description = "로그인한 사용자가 팀장이 아닌 경우", content = @Content)
     })
     @PostMapping("/{teamId}")
     public ResponseEntity<TeamResponse> updateTeamInfo(@Login Long memberId, @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest request){

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -11,6 +11,10 @@ import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.service.TeamService;
 import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
 import com.feedhanjum.back_end.team.service.dto.TeamUpdateDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,6 +31,11 @@ public class TeamController {
     private final TeamService teamService;
     private final MemberService memberService;
 
+    @Operation(summary = "팀 생성", description = "로그인한 사용자를 팀장으로 하는 팀을 생성한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "팀 생성에 성공함."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원이 팀 생성을 시도할 경우", content = @Content)
+    })
     @PostMapping("/create")
     public ResponseEntity<TeamResponse> createTeam(@Login Long memberId,
                                                    @Valid @RequestBody TeamCreateRequest request) {
@@ -36,6 +45,10 @@ public class TeamController {
         return new ResponseEntity<>(new TeamResponse(team), HttpStatus.CREATED);
     }
 
+    @Operation(summary = "내가 속한 팀 조회", description = "현재 로그인한 사용자가 가입한 모든 팀을 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회에 성공한 경우")
+    })
     @GetMapping("/my-teams")
     public ResponseEntity<List<TeamResponse>> getMyTeams(@Login Long memberId) {
         List<TeamResponse> teams = teamService.getMyTeams(memberId)
@@ -50,6 +63,11 @@ public class TeamController {
      *
      * @return 팀 정보 + 속한 회원 정보를 반환
      */
+    @Operation(summary = "팀 상세 정보 조회", description = "특정 팀의 상세 정보를 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "해당 팀의 정보 조회에 성공한 경우"),
+            @ApiResponse(responseCode = "404", description = "해당 팀을 조회할 권한이 없는 경우 - 팀 정보 숨김")
+    })
     @GetMapping("/{teamId}")
     public ResponseEntity<TeamDetailResponse> getTeamDetail(@Login Long memberId, @PathVariable Long teamId) {
         Team team = teamService.getTeam(teamId);
@@ -61,6 +79,11 @@ public class TeamController {
         return ResponseEntity.ok(teamDetailResponse);
     }
 
+    @Operation(summary = "팀원 조횐", description = "특정 팀에 존재하는 모든 사용자의 정보를 조회한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공."),
+            @ApiResponse(responseCode = "404", description = "해당 팀에 대한 조회 권한이 없을 경우 - 정보 숨김")
+    })
     @GetMapping("/{teamId}/members")
     public ResponseEntity<List<MemberDto>> getTeamMembers(@Login Long memberId, @PathVariable Long teamId) {
         List<MemberDto> membersByTeam = memberService.getMembersByTeam(memberId, teamId)
@@ -68,12 +91,24 @@ public class TeamController {
         return ResponseEntity.ok(membersByTeam);
     }
 
+    @Operation(summary = "팀원 추방", description = "특정 팀에 존재하는 특정 팀원을 제거한다. 팀장만이 사용 가능하다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "해당 팀원을 팀에서 제거하는데 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 팀 또는 팀원을 찾을 수 없는 경우"),
+            @ApiResponse(responseCode = "403", description = "로그인한 사용자가 팀장이 아닌 경우")
+    })
     @DeleteMapping("/{teamId}/member/{removeMemberId}")
     public ResponseEntity<Void> deleteMemberFromTeam(@Login Long memberId, @PathVariable Long teamId, @PathVariable Long removeMemberId) {
         teamService.removeTeamMember(memberId, teamId, removeMemberId);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "팀 정보 수정", description = "특정 팀의 정보를 수정한다. 탐장만이 사용 가능하다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "해당 팀원을 팀에서 제거하는데 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 팀 또는 팀원을 찾을 수 없는 경우"),
+            @ApiResponse(responseCode = "403", description = "로그인한 사용자가 팀장이 아닌 경우")
+    })
     @PostMapping("/{teamId}")
     public ResponseEntity<TeamResponse> updateTeamInfo(@Login Long memberId, @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest request){
         Team team = teamService.updateTeamInfo(memberId, teamId, new TeamUpdateDto(request));
@@ -81,6 +116,12 @@ public class TeamController {
         return ResponseEntity.ok(teamResponse);
     }
 
+    @Operation(summary = "팀장 위임", description = "특정 팀원에게 팀장 권한을 위임한다. 팀장만이 사용 가능하다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "해당 팀원에게 팀장 권한 위임 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 팀 또는 팀원을 찾을 수 없는 경우"),
+            @ApiResponse(responseCode = "403", description = "로그인한 사용자가 팀장이 아닌 경우")
+    })
     @PostMapping("/{teamId}/leader")
     public ResponseEntity<Void> delegateTeamLeader(@Login Long memberId,
                                                    @PathVariable Long teamId,
@@ -89,6 +130,12 @@ public class TeamController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "팀 탈퇴", description = "로그인한 사용자를 해당 팀에서 탈퇴시킨다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "해당 팀에서 탈퇴하는데 성공한 경우"),
+            @ApiResponse(responseCode = "404", description = "해당 팀 또는 팀원을 찾을 수 없는 경우 - 팀 정보 숨김"),
+            @ApiResponse(responseCode = "400", description = "로그인한 사용자가 2명 이상 존재하는 팀의 팀장인 경우")
+    })
     @DeleteMapping("/{teamId}/leave")
     public ResponseEntity<Void> leaveTeam(@Login Long memberId, @PathVariable Long teamId) {
         teamService.leaveTeam(memberId, teamId);

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -105,9 +105,10 @@ public class TeamController {
 
     @Operation(summary = "팀 정보 수정", description = "특정 팀의 정보를 수정한다. 탐장만이 사용 가능하다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "해당 팀원을 팀에서 제거하는데 성공"),
+            @ApiResponse(responseCode = "200", description = "팀 정보를 수정하는데 성공"),
             @ApiResponse(responseCode = "404", description = "해당 팀 또는 팀원을 찾을 수 없는 경우", content = @Content),
-            @ApiResponse(responseCode = "403", description = "로그인한 사용자가 팀장이 아닌 경우", content = @Content)
+            @ApiResponse(responseCode = "403", description = "로그인한 사용자가 팀장이 아닌 경우", content = @Content),
+            @ApiResponse(responseCode = "400", description = "요청한 입력값이 잘못되어있을 경우", content = @Content)
     })
     @PostMapping("/{teamId}")
     public ResponseEntity<TeamResponse> updateTeamInfo(@Login Long memberId, @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest request){

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamQueryRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamQueryRepository.java
@@ -17,8 +17,8 @@ public class TeamQueryRepository {
 
     public List<Team> findTeamByMemberId(Long memberId) {
         return jpaQueryFactory.select(team)
-                .from(teamMember)
-                .join(teamMember.team, team).fetchJoin()
+                .from(team)
+                .join(teamMember).on(teamMember.team.id.eq(team.id)).fetchJoin()
                 .where(teamMember.member.id.eq(memberId))
                 .fetch();
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
@@ -1,6 +1,7 @@
 package com.feedhanjum.back_end.member.controller;
 
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.member.controller.dto.ProfileChangeRequest;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.service.MemberService;
@@ -48,37 +49,21 @@ class MemberControllerTest {
     }
 
     @Test
-    @DisplayName("회원 이름 변경 컨트롤러 동작 확인")
-    void changeName_이름변경() {
+    @DisplayName("회원 정보 변경 컨트롤러 동작 확인")
+    void changeProfile_프로필변경() {
         // given
         Long memberId = 1L;
         String newName = "hoho";
+        ProfileImage profileImage = new ProfileImage("haha", "hehe");
         Member member = new Member(newName, "hoho", new ProfileImage("huhu", "hehe"));
-        when(memberService.changeName(memberId, newName)).thenReturn(member);
+        when(memberService.changeProfile(memberId, newName, profileImage)).thenReturn(member);
+        ProfileChangeRequest profileChangeRequest = new ProfileChangeRequest(newName, profileImage);
         // when
-        ResponseEntity<MemberDto> response = memberController.changeName(memberId, newName);
+        ResponseEntity<MemberDto> response = memberController.changeProfile(memberId, profileChangeRequest);
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         MemberDto memberDto = response.getBody();
         assertThat(memberDto).isNotNull();
         assertThat(memberDto.name()).isEqualTo(newName);
-    }
-
-    @Test
-    @DisplayName("회원 프로필 이미지 변경 컨트롤러 동작 확인")
-    void changeProfileImage_프로필이미지_변경() {
-        // given
-        Long memberId = 1L;
-        ProfileImage newProfileImage = new ProfileImage("green", "img2.png");
-        Member newMember = new Member("haha", "hoho", newProfileImage);
-        when(memberService.changeProfileImage(memberId, newProfileImage)).thenReturn(newMember);
-        // when
-        ResponseEntity<MemberDto> response = memberController.changeProfileImage(memberId, newProfileImage);
-        // then
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        MemberDto memberDto = response.getBody();
-        assertThat(memberDto).isNotNull();
-        assertThat(memberDto.profileImage().getBackgroundColor()).isEqualTo("green");
-        assertThat(memberDto.profileImage().getImage()).isEqualTo("img2.png");
     }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/service/MemberServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/service/MemberServiceTest.java
@@ -4,9 +4,11 @@ import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
 import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
 import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,9 @@ class MemberServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private TeamRepository teamRepository;
 
     @Mock
     private TeamMemberRepository teamMemberRepository;
@@ -74,32 +79,18 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("회원 이름 변경에 성공한다")
-    void changeName_이름변경() {
+    @DisplayName("회원 정보 변경에 성공한다")
+    void changeProfile() {
         // given
         Long memberId = 1L;
         Member member = new Member("haha", "hoho", new ProfileImage("huhu", "hehe"));
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         String newName = "hoho";
-        // when
-        Member result = memberService.changeName(memberId, newName);
-        // then
-        assertThat(result.getName()).isEqualTo(newName);
-    }
-
-    @Test
-    @DisplayName("회원 프로필 이미지 변경에 성공한다")
-    void changeProfileImage_프로필변경() {
-        // given
-        Long memberId = 1L;
-        Member member = new Member("haha", "hoho", new ProfileImage("huhu", "hehe"));
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         ProfileImage newProfileImage = new ProfileImage("hehe", "haha");
         // when
-        Member result = memberService.changeProfileImage(memberId, newProfileImage);
+        Member result = memberService.changeProfile(memberId, newName, newProfileImage);
         // then
-        assertThat(result.getProfileImage().getBackgroundColor()).isEqualTo("hehe");
-        assertThat(result.getProfileImage().getImage()).isEqualTo("haha");
+        assertThat(result.getName()).isEqualTo(newName);
     }
 
     @Test
@@ -113,6 +104,9 @@ class MemberServiceTest {
                 .thenReturn(Optional.of(teamMember));
         Member member = mock(Member.class);
         List<Member> expectedMembers = List.of(member);
+        Team team = mock(Team.class);
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(memberQueryRepository.findMembersByTeamId(teamId))
                 .thenReturn(expectedMembers);
 
@@ -127,8 +121,12 @@ class MemberServiceTest {
     @DisplayName("가입되지 않은 팀 조회 시 예외 발생")
     void getMembersByTeam_팀미가입예외() {
         //given
-        Long memberId = 2L;
-        Long teamId = 2L;
+        Long memberId = 1L;
+        Long teamId = 1L;
+        Member member = mock(Member.class);
+        Team team = mock(Team.class);
+        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
                 .thenReturn(Optional.empty());
 


### PR DESCRIPTION
# 관련 이슈
FD-297

# 변경된 점
- [x] 각 API에 대한 간단한 설명 추가
- [x] team query의 fetch join 의 루트 엔티티가 잘못 설정되어있던 문제 수정
- [x] 기본 자바 예외에 대한 ControllerAdvice 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
  • Enhanced authentication endpoints now support persistent sessions, ensuring users remain logged in until they sign out.  
  • A unified profile update now lets users change their name and profile image in a single action.

- **Documentation**  
  • API documentation across core features has been enriched, offering clearer endpoint summaries and improved response descriptions.

- **Refactor**  
  • Streamlined error handling and optimized flows in scheduling and team management operations for greater robustness.  
  • Improved error messaging in schedule updates for clearer communication.  
  • Enhanced API documentation for various endpoints in the Team and Schedule controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->