### PR TITLE
[FD-206] 홈에서 일정 역할 추가 화면 개발

### DIFF
--- a/front-end/src/api/useFeedback.js
+++ b/front-end/src/api/useFeedback.js
@@ -54,7 +54,7 @@ export const useFeedbackLike = (userId, feedbackId) => {
   });
 };
 
-export const useFeedbackCancelLike = (userId, feedbackId) => {
+export const useFeedbackLikeCancel = (userId, feedbackId) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () =>

--- a/front-end/src/pages/calendar/components/TodoAdd.jsx
+++ b/front-end/src/pages/calendar/components/TodoAdd.jsx
@@ -1,0 +1,133 @@
+import classNames from 'classnames';
+import Icon from '../../../components/Icon';
+import { useEffect, useRef, useState } from 'react';
+import { changeDayName, timePickerToDate } from '../../../utility/time';
+import LargeButton from '../../../components/buttons/LargeButton';
+import StickyWrapper from '../../../components/wrappers/StickyWrapper';
+import { showToast } from '../../../utility/handleToast';
+import { checkNewSchedule, isEmpty } from '../../../utility/inputChecker';
+import Todo from './Todo';
+
+/**
+ * 일정 추가 페이지
+ * @param {object} props
+ * @param {boolean} props.isOpen - 페이지 열림 여부
+ * @param {function} props.onClose - 페이지 닫기 함수
+ * @param {function} props.onSubmit - 일정 추가 완료 함수
+ * @param {Date} props.selectedDate - 선택된 날짜
+ */
+export default function TodoAdd({
+  isOpen,
+  onClose,
+  onSubmit,
+  selectedSchedule,
+}) {
+  const [todos, setTodo] = useState(
+    selectedSchedule?.todos?.filter((todo) => {
+      return todo.memberId === 1;
+    }).task ?? [],
+  );
+  const scrollRef = useRef(null);
+
+  useEffect(() => {
+    const newTodos =
+      selectedSchedule?.todos?.find((todo) => {
+        return todo.memberId === 1;
+      })?.task ?? [];
+    setTodo(newTodos);
+  }, [selectedSchedule]);
+
+  function clearData() {
+    setTodo([]);
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className={classNames(
+        'rounded-t-400 fixed right-0 left-0 z-1000 flex h-[calc(100%-60px)] max-w-[430px] flex-col overflow-y-auto bg-gray-800 px-5 transition-all duration-300',
+        isOpen ? 'visible bottom-0' : 'invisible -bottom-[100%]',
+      )}
+    >
+      <StickyWrapper bgColor='gray-800'>
+        <h1 className='subtitle-1 pt-5 text-center text-white'>
+          내 역할 추가하기
+        </h1>
+        <button
+          onClick={() => {
+            clearData();
+            onClose();
+          }}
+        >
+          <Icon name='delete' className='absolute top-5 right-0 text-white' />
+        </button>
+      </StickyWrapper>
+
+      <div className='h-8 shrink-0' />
+
+      <div className='flex items-center gap-2'>
+        <hr className='h-6 w-1.5 rounded-[2px] bg-lime-500' />
+        <h2 className='header-3 text-white'>
+          {`${selectedSchedule?.name ?? '5주차 리서치 과제'}`}
+        </h2>
+      </div>
+      <div className='h-3 shrink-0' />
+
+      <Todo todos={todos} setTodo={setTodo} scrollRef={scrollRef} />
+
+      <div className='h-11 shrink-0' />
+      <div className='flex-1' />
+
+      <div
+        className={`relative bottom-0 mb-5 max-w-[calc(390px)] transition-all duration-300`}
+      >
+        <LargeButton
+          isOutlined={false}
+          text={'완료'}
+          onClick={() => {
+            const newTodos = todos.filter((todo) => !isEmpty(todo));
+            setTodo(newTodos);
+            // TODO: 역할 추가
+            showToast('역할이 추가되었어요');
+            clearData();
+            onSubmit(true); // 추가 성공여부 파라미터로 받음
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// 메인페이지 import 추가
+// import ScheduleAction, {
+//   ScheduleActionType,
+// } from '../calendar/components/ScheduleAction';
+// import TodoAdd from '../calendar/components/TodoAdd';
+
+// 메인페이지 아래 추가
+/* {recentScheduleData && (
+        <ScheduleAction
+          type={ScheduleActionType.ADD}
+          isOpen={true}
+          onSubmit={() => {
+            // 닫기
+            // TODO: 일정 조회
+          }}
+          onClose={() => {
+            // 닫기
+          }}
+          selectedDateFromParent={new Date()}
+          selectedSchedule={recentScheduleData}
+        />
+      )} */
+/* <TodoAdd
+        isOpen={true}
+        onSubmit={() => {
+          // 닫기
+          // TODO: 할일 조회
+        }}
+        onClose={() => {
+          // 닫기
+        }}
+        selectedSchedule={recentScheduleData}
+      /> */

--- a/front-end/src/pages/calendar/components/TodoAdd.jsx
+++ b/front-end/src/pages/calendar/components/TodoAdd.jsx
@@ -97,37 +97,3 @@ export default function TodoAdd({
     </div>
   );
 }
-
-// 메인페이지 import 추가
-// import ScheduleAction, {
-//   ScheduleActionType,
-// } from '../calendar/components/ScheduleAction';
-// import TodoAdd from '../calendar/components/TodoAdd';
-
-// 메인페이지 아래 추가
-/* {recentScheduleData && (
-        <ScheduleAction
-          type={ScheduleActionType.ADD}
-          isOpen={true}
-          onSubmit={() => {
-            // 닫기
-            // TODO: 일정 조회
-          }}
-          onClose={() => {
-            // 닫기
-          }}
-          selectedDateFromParent={new Date()}
-          selectedSchedule={recentScheduleData}
-        />
-      )} */
-/* <TodoAdd
-        isOpen={true}
-        onSubmit={() => {
-          // 닫기
-          // TODO: 할일 조회
-        }}
-        onClose={() => {
-          // 닫기
-        }}
-        selectedSchedule={recentScheduleData}
-      /> */

--- a/front-end/src/pages/feedback/components/FeedBack.jsx
+++ b/front-end/src/pages/feedback/components/FeedBack.jsx
@@ -3,7 +3,7 @@ import Icon from '../../../components/Icon';
 import ProfileImage from '../../../components/ProfileImage';
 import Tag from '../../../components/Tag';
 import {
-  useFeedbackCancelLike,
+  useFeedbackLikeCancel,
   useFeedbackLike,
 } from '../../../api/useFeedback';
 
@@ -25,7 +25,7 @@ export default function FeedBack({ feedbackType, data }) {
   const date = data.createdAt.split('T')[0].replace(/-/g, '.');
 
   const { mutate: likeFeedback } = useFeedbackLike(1, data.feedbackId);
-  const { mutate: cancelLikeFeedback } = useFeedbackCancelLike(
+  const { mutate: cancelLikeFeedback } = useFeedbackLikeCancel(
     1,
     data.feedbackId,
   );
@@ -123,54 +123,3 @@ export default function FeedBack({ feedbackType, data }) {
     </div>
   );
 }
-
-// const feedbackData = [
-//     {
-//       feedbackType: 'RECEIVE',
-//       teamMate: '홍길동',
-//       teamName: '팀 이름',
-//       profileImage: {
-//         iconName: 'shark',
-//         color: '#62BFCA',
-//       },
-//       recordDate: '2025-01-29',
-//       content:
-//         '주요 내용을 좀 더 구체적으로 표현하면 이해하기 쉬울 것 같아요. 특히, 두 번째 섹션에서 예시를 추가하면 더 설득력이 높아질 것 같습니다!',
-//       keywords: [
-//         '명확하게 적기',
-//         '해결점 위주',
-//         '직설적인 말투',
-//         '항상 긍정적인 태도',
-//         '설득력',
-//       ],
-//       heart: true,
-//     },
-//     {
-//       feedbackType: 'SEND',
-//       teamMate: '홍길동',
-//       teamName: '팀 이름',
-//       profileImage: {
-//         iconName: 'shark',
-//         color: '#62BFCA',
-//       },
-//       recordDate: '2025-01-29',
-//       content:
-//         '주요 내용을 좀 더 구체적으로 표현하면 이해하기 쉬울 것 같아요. 특히, 두 번째 섹션에서 예시를 추가하면 더 설득력이 높아질 것 같습니다!',
-//       keywords: [
-//         '명확하게 적기',
-//         '해결점 위주',
-//         '직설적인 말투',
-//         '항상 긍정적인 태도',
-//         '설득력',
-//       ],
-//       heart: true,
-//     },
-//     {
-//       feedbackType: 'SELF',
-//       teamName: '팀 이름',
-//       scheduleName: '4주차 리서치 과제',
-//       recordDate: '2025.01.29',
-//       content:
-//         '이번 프로젝트를 통해 팀원들과의 소통이 얼마나 중요한지 다시 한번 느낌. 특히 중간 점검 회의에서 나온 피드백이 큰 도움이 되었고, 최종 결과물의 완성도를 높이는 데 기여했다. 다음에는 일정 관리를 더욱 철저히 하고, 사전 준비를 강화해야겠다고 느껴졌음.',
-//     },
-//   ];

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -15,10 +15,16 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../../slider.css';
 import { filterNotifications } from '../../utility/handleNotification';
+import ScheduleAction, {
+  ScheduleActionType,
+} from '../calendar/components/ScheduleAction';
+import TodoAdd from '../calendar/components/TodoAdd';
 
 export default function MainPage() {
   const [selectedTeamId, setSelectedTeamId] = useState(1);
   const [banners, setBanners] = useState();
+  const [isTodoAddOpen, setIsTodoAddOpen] = useState(false);
+  const [isScheduleOpen, setIsScheduleOpen] = useState(false);
 
   const { data: teamsData } = useMyTeams();
   const { data: recentScheduleData } = useMainCard(selectedTeamId);
@@ -67,6 +73,34 @@ export default function MainPage() {
       <div className='h-8' />
       {matesData && <MainCard2 teamMates={matesData} className='' />}
       <div className='h-8' />
+      {recentScheduleData && (
+        <ScheduleAction
+          type={ScheduleActionType.ADD}
+          isOpen={isScheduleOpen}
+          onSubmit={() => {
+            setIsScheduleOpen(!isScheduleOpen);
+            // TODO: 일정 조회
+          }}
+          onClose={() => {
+            setIsScheduleOpen(!isScheduleOpen);
+          }}
+          selectedDateFromParent={new Date()}
+          selectedSchedule={recentScheduleData}
+        />
+      )}
+      {recentScheduleData && (
+        <TodoAdd
+          isOpen={isTodoAddOpen}
+          onSubmit={() => {
+            setIsTodoAddOpen(!isTodoAddOpen);
+            // TODO: 할일 조회
+          }}
+          onClose={() => {
+            setIsTodoAddOpen(!isTodoAddOpen);
+          }}
+          selectedSchedule={recentScheduleData}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
홈에서 일정이나 역할을 추가할때 올라오는 바텀시트 추가했습니다.
- 역할 추가 컴포넌트 구현
- 메인페이지에 두 컴포넌트 삽입 (MainPage 코드 하단에 추가)
- 두 컴포넌트 보이게/사라지게 하는 상태 추가

<img width="430" alt="스크린샷 2025-02-09 오후 8 59 32" src="https://github.com/user-attachments/assets/7f6c6f4c-d4e8-4424-b6b9-d1b4b17a8906" />
<img width="430" alt="스크린샷 2025-02-09 오후 9 00 09" src="https://github.com/user-attachments/assets/63c5f35e-f49d-4c9e-9194-18537b129930" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an interactive modal for adding tasks to schedules, streamlining the task management experience.
	- Enhanced the main interface by integrating dynamic scheduling actions for improved usability.

- **Refactor**
	- Updated the underlying feedback cancellation process to ensure consistency while maintaining the existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->