### PR TITLE
[FD-103, FD-312]  피드백 선호 정보 조회 & 피드백 선호 정보 수정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/AuthController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
         String name = request.name();
         ProfileImage profileImage = request.profileImage();
 
-        MemberDetails savedMember = authService.registerMember(member, name, profileImage);
+        MemberDetails savedMember = authService.registerMember(member, name, profileImage, request.feedbackPreference());
 
         session.removeAttribute(SessionConst.SIGNUP_TOKEN_VERIFIED_EMAIL);
         MemberSignupResponse response = memberMapper.toResponse(savedMember);

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/dto/MemberSignupRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/dto/MemberSignupRequest.java
@@ -2,11 +2,15 @@ package com.feedhanjum.back_end.auth.controller.dto;
 
 import com.feedhanjum.back_end.auth.domain.MemberDetails;
 import com.feedhanjum.back_end.core.constraints.ByteLength;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.util.List;
 
 public record MemberSignupRequest(
         @Schema(description = "계정 등록에 사용할 이메일 정보. 유일해야 한다.")
@@ -25,6 +29,10 @@ public record MemberSignupRequest(
         String name,
 
         @Schema(description = "사용자가 사용할 프로필 이미지")
-        ProfileImage profileImage
+        ProfileImage profileImage,
+
+        @NotNull
+        @Schema(description = "사용자의 피드백 선호 정보")
+        List<FeedbackPreference> feedbackPreference
 ) {
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/service/AuthService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/service/AuthService.java
@@ -9,6 +9,7 @@ import com.feedhanjum.back_end.auth.exception.PasswordResetTokenNotValidExceptio
 import com.feedhanjum.back_end.auth.exception.SignupTokenNotValidException;
 import com.feedhanjum.back_end.auth.passwordencoder.PasswordEncoder;
 import com.feedhanjum.back_end.auth.repository.MemberDetailsRepository;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -33,16 +35,17 @@ public class AuthService {
      * 회원가입을 처리하는 서비스
      * Member 테이블에서 ID값을 받아와 저장하고, 암호를 해싱한 뒤 반환한다.
      *
-     * @param memberDetails 사용자의 인증을 담당하는 정보
-     * @param name          사용자가 설정한 활동 이름
+     * @param memberDetails       사용자의 인증을 담당하는 정보
+     * @param name                사용자가 설정한 활동 이름
+     * @param feedbackPreferences
      * @return id값이 할당된 인증 정보 반환
      * @throws EmailAlreadyExistsException 이미 이메일이 존재하는 경우
      */
     @Transactional
-    public MemberDetails registerMember(MemberDetails memberDetails, String name, ProfileImage profileImage) {
+    public MemberDetails registerMember(MemberDetails memberDetails, String name, ProfileImage profileImage, List<FeedbackPreference> feedbackPreferences) {
 
         validateEmail(memberDetails.getEmail());
-        Member member = new Member(name, memberDetails.getEmail(), profileImage);
+        Member member = new Member(name, memberDetails.getEmail(), profileImage, feedbackPreferences);
         Member savedMember = memberRepository.save(member);
         String hashedPassword = passwordEncoder.encode(memberDetails.getPassword());
         MemberDetails savedMemberDetails = new MemberDetails(savedMember.getId(), memberDetails.getEmail(), hashedPassword);

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.feedhanjum.back_end.member.controller;
 import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
 import com.feedhanjum.back_end.member.controller.dto.ProfileChangeRequest;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,13 +39,27 @@ public class MemberController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경된 회원 정보를 반환한다. " +
                     "세션을 통해 받은 회원의 정보를 수정하기 때문에, 다른 회원의 정보를 수정할 수 없다."),
-            @ApiResponse(responseCode = "400", description = "변경할 회원 정보 폼이 잘못됐을 경우, 주로 이름이 제한 범위 밖인 경우", content = @Content)
+            @ApiResponse(responseCode = "400", description = "변경할 회원 정보 폼이 잘못됐을 경우, 주로 이름이 제한 범위 밖인 경우", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 회원이 존재하지 않을 경우", content = @Content)
     })
     @PostMapping("/member")
     public ResponseEntity<MemberDto> changeProfile(@Login Long memberId, @Valid @RequestBody ProfileChangeRequest profileChageRequest) {
         String name = profileChageRequest.name();
         ProfileImage profileImage = profileChageRequest.profileImage();
         MemberDto memberDto = new MemberDto(memberService.changeProfile(memberId, name, profileImage));
+        return new ResponseEntity<>(memberDto, HttpStatus.OK);
+    }
+
+    @Operation(summary = "회원의 피드백 선호 정보를 변경한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "변경된 회원 정보를 반환한다. " +
+                    "세션을 통해 받은 회원의 정보를 수정하기 때문에, 다른 회원의 정보를 수정할 수 없다."),
+            @ApiResponse(responseCode = "400", description = "변경할 피드백 선호도 정보가 잘못됐을 경우", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 회원이 존재하지 않을 경우", content = @Content)
+    })
+    @PostMapping("/member/feedback-prefer")
+    public ResponseEntity<MemberDto> changeFeedbackPreference(@Login Long memberId, @Valid @RequestBody List<FeedbackPreference> feedbackPreferences) {
+        MemberDto memberDto = new MemberDto(memberService.changeFeedbackPreference(memberId, feedbackPreferences));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -58,8 +58,8 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "해당 회원이 존재하지 않을 경우", content = @Content)
     })
     @GetMapping("/member/feedback-prefer")
-    public ResponseEntity<MemberFeedbackPreferenceDto> getFeedbackPreference(@Login Long memberId) {
-        MemberFeedbackPreferenceDto memberDto = new MemberFeedbackPreferenceDto(memberService.getMemberFeedbackPreference(memberId));
+    public ResponseEntity<MemberFeedbackPreferenceDto> getFeedbackPreference(Long findMemberId) {
+        MemberFeedbackPreferenceDto memberDto = new MemberFeedbackPreferenceDto(memberService.getMemberFeedbackPreference(findMemberId));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.feedhanjum.back_end.member.controller;
 
 import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.member.controller.dto.MemberFeedbackPreferenceDto;
 import com.feedhanjum.back_end.member.controller.dto.ProfileChangeRequest;
 import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
@@ -50,7 +51,19 @@ public class MemberController {
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 
-    @Operation(summary = "회원의 피드백 선호 정보를 변경한다.")
+
+    @Operation(summary = "피드백 선호 정보 조회", description = "회원의 피드백 선호 정보를 반환한다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원의 피드백 선호 정보를 반환한다."),
+            @ApiResponse(responseCode = "404", description = "해당 회원이 존재하지 않을 경우", content = @Content)
+    })
+    @GetMapping("/member/feedback-prefer")
+    public ResponseEntity<MemberFeedbackPreferenceDto> getFeedbackPreference(@Login Long memberId) {
+        MemberFeedbackPreferenceDto memberDto = new MemberFeedbackPreferenceDto(memberService.getMemberFeedbackPreference(memberId));
+        return new ResponseEntity<>(memberDto, HttpStatus.OK);
+    }
+
+    @Operation(summary = "피드백 선호 정보 변경", description = "회원의 피드백 선호 정보를 변경한다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경된 회원 정보를 반환한다. " +
                     "세션을 통해 받은 회원의 정보를 수정하기 때문에, 다른 회원의 정보를 수정할 수 없다."),
@@ -58,8 +71,8 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "해당 회원이 존재하지 않을 경우", content = @Content)
     })
     @PostMapping("/member/feedback-prefer")
-    public ResponseEntity<MemberDto> changeFeedbackPreference(@Login Long memberId, @Valid @RequestBody List<FeedbackPreference> feedbackPreferences) {
-        MemberDto memberDto = new MemberDto(memberService.changeFeedbackPreference(memberId, feedbackPreferences));
+    public ResponseEntity<MemberFeedbackPreferenceDto> changeFeedbackPreference(@Login Long memberId, @Valid @RequestBody List<FeedbackPreference> feedbackPreferences) {
+        MemberFeedbackPreferenceDto memberDto = new MemberFeedbackPreferenceDto(memberService.changeFeedbackPreference(memberId, feedbackPreferences));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/MemberDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/MemberDto.java
@@ -1,11 +1,8 @@
 package com.feedhanjum.back_end.member.controller.dto;
 
-import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.util.List;
 
 public record MemberDto(
         @Schema(description = "회원의 ID")
@@ -18,12 +15,9 @@ public record MemberDto(
         String email,
 
         @Schema(description = "회원의 프로필 이미지")
-        ProfileImage profileImage,
-
-        @Schema(description = "회원의 피드백 선호 정보")
-        List<FeedbackPreference> feedbackPreferences
+        ProfileImage profileImage
 ) {
     public MemberDto(Member member) {
-        this(member.getId(), member.getName(), member.getEmail(), member.getProfileImage(), member.getFeedbackPreferences().stream().toList());
+        this(member.getId(), member.getName(), member.getEmail(), member.getProfileImage());
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/MemberDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/MemberDto.java
@@ -1,10 +1,29 @@
 package com.feedhanjum.back_end.member.controller.dto;
 
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record MemberDto(Long id, String name, String email, ProfileImage profileImage) {
+import java.util.List;
+
+public record MemberDto(
+        @Schema(description = "회원의 ID")
+        Long id,
+
+        @Schema(description = "회원의 활동 이름")
+        String name,
+
+        @Schema(description = "회원이 회원가입 시 사용했던 이메일")
+        String email,
+
+        @Schema(description = "회원의 프로필 이미지")
+        ProfileImage profileImage,
+
+        @Schema(description = "회원의 피드백 선호 정보")
+        List<FeedbackPreference> feedbackPreferences
+) {
     public MemberDto(Member member) {
-        this(member.getId(), member.getName(), member.getEmail(), member.getProfileImage());
+        this(member.getId(), member.getName(), member.getEmail(), member.getProfileImage(), member.getFeedbackPreferences().stream().toList());
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/MemberFeedbackPreferenceDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/dto/MemberFeedbackPreferenceDto.java
@@ -1,0 +1,29 @@
+package com.feedhanjum.back_end.member.controller.dto;
+
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.domain.ProfileImage;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record MemberFeedbackPreferenceDto(
+        @Schema(description = "회원의 ID")
+        Long id,
+
+        @Schema(description = "회원의 활동 이름")
+        String name,
+
+        @Schema(description = "회원이 회원가입 시 사용했던 이메일")
+        String email,
+
+        @Schema(description = "회원의 프로필 이미지")
+        ProfileImage profileImage,
+
+        @Schema(description = "회원의 피드백 선호 정보")
+        List<FeedbackPreference> feedbackPreferences
+) {
+    public MemberFeedbackPreferenceDto(Member member) {
+        this(member.getId(), member.getName(), member.getEmail(), member.getProfileImage(), member.getFeedbackPreferences().stream().toList());
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.HashSet;
 import java.util.List;
@@ -24,10 +25,11 @@ public class Member {
     @Embedded
     private ProfileImage profileImage;
 
-    @ElementCollection(targetClass = FeedbackPreference.class)
+    @ElementCollection(targetClass = FeedbackPreference.class, fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     @CollectionTable(name = "feedback_preference", joinColumns = @JoinColumn(name = "member_id"))
     @Column(name = "feedback_preference")
+    @BatchSize(size = 16)
     private Set<FeedbackPreference> feedbackPreferences = new HashSet<>();
 
     public Member(String name, String email, ProfileImage profileImage, List<FeedbackPreference> feedbackPreferences) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
@@ -45,6 +45,10 @@ public class Member {
         this.name = name;
     }
 
+    public void changeFeedbackPreference(List<FeedbackPreference> feedbackPreferences) {
+        setFeedbackPreference(feedbackPreferences);
+    }
+
     @Override
     public final boolean equals(Object o) {
         if (this == o) return true;

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
@@ -5,7 +5,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,10 +24,17 @@ public class Member {
     @Embedded
     private ProfileImage profileImage;
 
-    public Member(String name, String email, ProfileImage profileImage) {
+    @ElementCollection(targetClass = FeedbackPreference.class)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "feedback_preference", joinColumns = @JoinColumn(name = "member_id"))
+    @Column(name = "feedback_preference")
+    private Set<FeedbackPreference> feedbackPreferences = new HashSet<>();
+
+    public Member(String name, String email, ProfileImage profileImage, List<FeedbackPreference> feedbackPreferences) {
         this.name = name;
         this.email = email;
         this.profileImage = profileImage;
+        setFeedbackPreference(feedbackPreferences);
     }
 
     public void changeProfile(ProfileImage profileImage) {
@@ -41,5 +51,21 @@ public class Member {
         if (o instanceof Member m)
             return getId() != null && Objects.equals(getId(), m.getId());
         return false;
+    }
+
+    private void setFeedbackPreference(List<FeedbackPreference> feedbackPreferences) {
+        if (feedbackPreferences == null) {
+            throw new IllegalArgumentException("피드백 선호 정보를 입력해주세요.");
+        }
+        int countContentPreference = FeedbackPreference.countContentPreference(feedbackPreferences);
+        int countStylePreference = FeedbackPreference.countStylePreference(feedbackPreferences);
+        if (countContentPreference < 1 || countContentPreference > 2) {
+            throw new IllegalArgumentException("피드백 내용 선호 정보를 1개 또는 2개 넣어주세요.");
+        }
+        if (countStylePreference < 1 || countStylePreference > 2) {
+            throw new IllegalArgumentException("피드백 스타일 선호 정보를 1개 또는 2개 넣어주세요.");
+        }
+        this.feedbackPreferences.clear();
+        this.feedbackPreferences.addAll(feedbackPreferences);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/repository/MemberRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/repository/MemberRepository.java
@@ -2,6 +2,11 @@ package com.feedhanjum.back_end.member.repository;
 
 import com.feedhanjum.back_end.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    @Query("select m from Member m join fetch m.feedbackPreferences fp")
+    Optional<Member> findMemberAndFeedbackPreferenceById(Long id);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/repository/MemberRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/repository/MemberRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    @Query("select m from Member m join fetch m.feedbackPreferences fp")
+    @Query("select m from Member m join fetch m.feedbackPreferences fp where m.id = :id")
     Optional<Member> findMemberAndFeedbackPreferenceById(Long id);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.feedhanjum.back_end.member.service;
 
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
@@ -39,6 +40,17 @@ public class MemberService {
         loginMember.changeName(name);
         loginMember.changeProfile(profileImage);
         return loginMember;
+    }
+
+    /**
+     * @throws IllegalArgumentException 피드백 선택이 요구사항을 만족하지 못했을 경우
+     * @throws EntityNotFoundException  해당 사용자를 찾을 수 없는 경우
+     */
+    @Transactional
+    public Member changeFeedbackPreference(Long memberId, List<FeedbackPreference> feedbackPreferences) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+        member.changeFeedbackPreference(feedbackPreferences);
+        return member;
     }
 
     /**

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/service/MemberService.java
@@ -64,4 +64,12 @@ public class MemberService {
             throw new TeamMembershipNotFoundException("속해있는 팀에 대한 정보만 접근 가능합니다.");
         return memberQueryRepository.findMembersByTeamId(teamId);
     }
+
+    /**
+     * @throws EntityNotFoundException 해당 사용자를 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public Member getMemberFeedbackPreference(Long memberId) {
+        return memberRepository.findMemberAndFeedbackPreferenceById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+    }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/auth/service/AuthServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/auth/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import com.feedhanjum.back_end.auth.exception.EmailAlreadyExistsException;
 import com.feedhanjum.back_end.auth.exception.InvalidCredentialsException;
 import com.feedhanjum.back_end.auth.passwordencoder.PasswordEncoder;
 import com.feedhanjum.back_end.auth.repository.MemberDetailsRepository;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,17 +48,18 @@ class AuthServiceTest {
         void registerMember_success() {
             MemberDetails inputMember = new MemberDetails(null, "test@example.com", "pass1234");
             String name = "홍길동";
+            List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
 
             when(memberDetailsRepository.findByEmail("test@example.com"))
                     .thenReturn(Optional.empty());
 
-            Member savedMember = new Member(name, "test@example.com", null);
+            Member savedMember = new Member(name, "test@example.com", null, feedbackPreferences);
             when(memberRepository.save(any(Member.class))).thenReturn(savedMember);
 
             MemberDetails resultMemberDetails = new MemberDetails(1L, "test@example.com", "pass1234");
             when(memberDetailsRepository.save(any(MemberDetails.class))).thenReturn(resultMemberDetails);
 
-            MemberDetails saved = authService.registerMember(inputMember, name, null);
+            MemberDetails saved = authService.registerMember(inputMember, name, null, feedbackPreferences);
 
             assertThat(saved).isNotNull();
             assertThat(saved.getId()).isEqualTo(1L);
@@ -76,12 +79,13 @@ class AuthServiceTest {
         @DisplayName("이메일 중복 시 EmailAlreadyExistsException 발생")
         void registerMember_fail_emailAlreadyExists() {
             MemberDetails inputMember = new MemberDetails(null, "test@example.com", "pass1234");
+            List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
             String name = "홍길동";
 
             when(memberDetailsRepository.findByEmail("test@example.com"))
                     .thenReturn(Optional.of(new MemberDetails(999L, "test@example.com", "any")));
 
-            assertThatThrownBy(() -> authService.registerMember(inputMember, name, null))
+            assertThatThrownBy(() -> authService.registerMember(inputMember, name, null, feedbackPreferences))
                     .isInstanceOf(EmailAlreadyExistsException.class)
                     .hasMessage("이미 사용 중인 이메일입니다.");
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/FeedbackControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/FeedbackControllerTest.java
@@ -15,6 +15,7 @@ import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.feedback.repository.FeedbackRepository;
 import com.feedhanjum.back_end.feedback.service.dto.ReceivedFeedbackDto;
 import com.feedhanjum.back_end.feedback.service.dto.SentFeedbackDto;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -82,7 +83,8 @@ class FeedbackControllerTest {
     private final Clock clock = Clock.fixed(Instant.parse("2025-01-10T12:00:00Z"), ZoneId.systemDefault());
 
     private Member createMember(String name) {
-        return new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        return new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name), feedbackPreferences);
     }
 
     private Team createTeam(String name, Member leader) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/RetrospectControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/RetrospectControllerTest.java
@@ -10,6 +10,7 @@ import com.feedhanjum.back_end.feedback.controller.dto.response.RetrospectRespon
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.feedback.domain.Retrospect;
 import com.feedhanjum.back_end.feedback.repository.RetrospectRepository;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -65,7 +66,8 @@ class RetrospectControllerTest {
 
 
     private Member createMember(String name) {
-        return new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        return new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name), feedbackPreferences);
     }
 
     private Team createTeam(String name, Member leader) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/repository/FeedbackQueryRepositoryTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/repository/FeedbackQueryRepositoryTest.java
@@ -4,6 +4,7 @@ import com.feedhanjum.back_end.core.config.QuerydslConfig;
 import com.feedhanjum.back_end.feedback.domain.Feedback;
 import com.feedhanjum.back_end.feedback.domain.FeedbackFeeling;
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -90,8 +91,9 @@ class FeedbackQueryRepositoryTest {
 
         @BeforeEach
         void setUp() {
-            member1 = new Member("member1", "email1@email.com", new ProfileImage("bg1", "profile1"));
-            member2 = new Member("member2", "email2@email.com", new ProfileImage("bg1", "profile1"));
+            List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+            member1 = new Member("member1", "email1@email.com", new ProfileImage("bg1", "profile1"), feedbackPreferences);
+            member2 = new Member("member2", "email2@email.com", new ProfileImage("bg1", "profile1"), feedbackPreferences);
             memberRepository.saveAll(List.of(member1, member2));
 
             team1 = new Team("team1", member1, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS);
@@ -285,8 +287,9 @@ class FeedbackQueryRepositoryTest {
 
         @BeforeEach
         void setUp() {
-            member1 = new Member("member1", "email1@email.com", new ProfileImage("bg1", "profile1"));
-            member2 = new Member("member2", "email2@email.com", new ProfileImage("bg1", "profile1"));
+            List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+            member1 = new Member("member1", "email1@email.com", new ProfileImage("bg1", "profile1"), feedbackPreferences);
+            member2 = new Member("member2", "email2@email.com", new ProfileImage("bg1", "profile1"), feedbackPreferences);
             memberRepository.saveAll(List.of(member1, member2));
 
             team1 = new Team("team1", member1, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS);

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -10,6 +10,7 @@ import com.feedhanjum.back_end.feedback.event.FrequentFeedbackCreatedEvent;
 import com.feedhanjum.back_end.feedback.event.RegularFeedbackCreatedEvent;
 import com.feedhanjum.back_end.feedback.exception.NoRegularFeedbackRequestException;
 import com.feedhanjum.back_end.feedback.repository.FeedbackRepository;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -75,7 +76,8 @@ class FeedbackServiceTest {
     private final AtomicLong nextId = new AtomicLong(1L);
 
     private Member createMember(String name) {
-        Member member = new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name), feedbackPreferences);
         ReflectionTestUtils.setField(member, "id", nextId.getAndIncrement());
         return member;
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/RetrospectServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/RetrospectServiceTest.java
@@ -4,6 +4,7 @@ import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.feedback.domain.Retrospect;
 import com.feedhanjum.back_end.feedback.repository.RetrospectQueryRepository;
 import com.feedhanjum.back_end.feedback.repository.RetrospectRepository;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -46,7 +47,8 @@ class RetrospectServiceTest {
     private final AtomicLong nextId = new AtomicLong(1L);
 
     private Member createMember(String name) {
-        Member member = new Member(name, name + "@email.com", new ProfileImage("bg " + name, "image " + name));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member(name, name + "@email.com", new ProfileImage("bg " + name, "image " + name), feedbackPreferences);
         ReflectionTestUtils.setField(member, "id", nextId.getAndIncrement());
         return member;
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.feedhanjum.back_end.member.controller;
 
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
 import com.feedhanjum.back_end.member.controller.dto.ProfileChangeRequest;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.service.MemberService;
@@ -14,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -32,7 +35,8 @@ class MemberControllerTest {
     void getMemberById_정상조회() {
         //given
         Long memberId = 1L;
-        Member member = new Member("홍길동", "hong@example.com", new ProfileImage("blue", "img.png"));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member("홍길동", "hong@example.com", new ProfileImage("blue", "img.png"), feedbackPreferences);
         ReflectionTestUtils.setField(member, "id", memberId);
         when(memberService.getMemberById(memberId)).thenReturn(member);
 
@@ -55,7 +59,8 @@ class MemberControllerTest {
         Long memberId = 1L;
         String newName = "hoho";
         ProfileImage profileImage = new ProfileImage("haha", "hehe");
-        Member member = new Member(newName, "hoho", new ProfileImage("huhu", "hehe"));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member(newName, "hoho", new ProfileImage("huhu", "hehe"), feedbackPreferences);
         when(memberService.changeProfile(memberId, newName, profileImage)).thenReturn(member);
         ProfileChangeRequest profileChangeRequest = new ProfileChangeRequest(newName, profileImage);
         // when

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/domain/MemberTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/domain/MemberTest.java
@@ -3,6 +3,8 @@ package com.feedhanjum.back_end.member.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MemberTest {
@@ -12,9 +14,10 @@ class MemberTest {
     void memberConstructor_회원생성() {
         // given
         ProfileImage profileImage = new ProfileImage("blue", "default.png");
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
 
         // when
-        Member member = new Member("haha", "haha@example.com", profileImage);
+        Member member = new Member("haha", "haha@example.com", profileImage, feedbackPreferences);
 
         // then
         assertThat(member.getName()).isEqualTo("haha");
@@ -29,7 +32,8 @@ class MemberTest {
         // given
         ProfileImage oldProfile = new ProfileImage("blue", "default.png");
         ProfileImage newProfile = new ProfileImage("red", "new.png");
-        Member member = new Member("haha", "haha@example.com", oldProfile);
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member("haha", "haha@example.com", oldProfile, feedbackPreferences);
 
         // when
         member.changeProfile(newProfile);
@@ -44,7 +48,8 @@ class MemberTest {
     void changeName_이름변경() {
         // given
         ProfileImage profileImage = new ProfileImage("blue", "default.png");
-        Member member = new Member("haha", "haha@example.com", profileImage);
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member("haha", "haha@example.com", profileImage, feedbackPreferences);
 
         // when
         member.changeName("hoho");

--- a/back-end/src/test/java/com/feedhanjum/back_end/member/service/MemberServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.feedhanjum.back_end.member.service;
 
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
@@ -49,7 +50,8 @@ class MemberServiceTest {
     void getMemberById_정상조회() {
         //given
         Long memberId = 1L;
-        Member member = new Member("홍길동", "hong@example.com", new ProfileImage("blue", "img.png"));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member("홍길동", "hong@example.com", new ProfileImage("blue", "img.png"), feedbackPreferences);
         ReflectionTestUtils.setField(member, "id", memberId);
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
 
@@ -83,7 +85,8 @@ class MemberServiceTest {
     void changeProfile() {
         // given
         Long memberId = 1L;
-        Member member = new Member("haha", "hoho", new ProfileImage("huhu", "hehe"));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member("haha", "hoho", new ProfileImage("huhu", "hehe"), feedbackPreferences);
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
         String newName = "hoho";
         ProfileImage newProfileImage = new ProfileImage("hehe", "haha");

--- a/back-end/src/test/java/com/feedhanjum/back_end/notification/controller/InAppNotificationControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/notification/controller/InAppNotificationControllerTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.feedhanjum.back_end.auth.infra.SessionConst;
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -65,7 +66,8 @@ class InAppNotificationControllerTest {
 
 
     private Member createMember(String name) {
-        return new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        return new Member(name, name + "@test.com", new ProfileImage("bg-" + name, "profile-" + name), feedbackPreferences);
     }
 
     private Team createTeam(String name, Member leader) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
@@ -2,6 +2,7 @@ package com.feedhanjum.back_end.team.controller;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.service.MemberService;
 import com.feedhanjum.back_end.team.controller.dto.TeamCreateRequest;
@@ -47,13 +48,14 @@ class TeamControllerTest {
         Long memberId = 1L;
         LocalDate startDate = LocalDate.now().plusDays(1);
         LocalDate endDate = LocalDate.now().plusDays(10);
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
         TeamCreateRequest request = new TeamCreateRequest("haha", startDate,
                 endDate, FeedbackType.ANONYMOUS);
         TeamCreateDto teamCreateDto = new TeamCreateDto(request);
         TeamResponse teamResponse = new TeamResponse(null, "haha", startDate,
-                endDate, FeedbackType.ANONYMOUS, new MemberDto(new Member("haha", "haha@hoho", null)));
+                endDate, FeedbackType.ANONYMOUS, new MemberDto(new Member("haha", "haha@hoho", null, feedbackPreferences)));
         when(teamService.createTeam(memberId, teamCreateDto))
-                .thenReturn(new Team("haha", new Member("haha", "haha@hoho", null),
+                .thenReturn(new Team("haha", new Member("haha", "haha@hoho", null, feedbackPreferences),
                         request.startDate(), request.endDate(), request.feedbackType()));
 
         //when
@@ -70,7 +72,8 @@ class TeamControllerTest {
     void getMyTeams_팀조회_컨트롤러() {
         //given
         Long memberId = 1L;
-        Team team = new Team("haha", new Member("haha", "haha@hoho", null), LocalDate.now().plusDays(1),
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Team team = new Team("haha", new Member("haha", "haha@hoho", null, feedbackPreferences), LocalDate.now().plusDays(1),
                 LocalDate.now().plusDays(10), FeedbackType.ANONYMOUS);
         TeamResponse teamResponse = new TeamResponse(team);
         when(teamService.getMyTeams(memberId)).thenReturn(List.of(team));
@@ -92,10 +95,11 @@ class TeamControllerTest {
         Long memberId = 2L;
         LocalDate now = LocalDate.now();
 
-        Member leader = new Member("haha", "haha", null);
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member leader = new Member("haha", "haha", null, feedbackPreferences);
         Team dummyTeam = new Team("haha", leader, now, now.plusDays(1), FeedbackType.IDENTIFIED);
 
-        Member dummyMember = new Member("hoho", "huhu", null);
+        Member dummyMember = new Member("hoho", "huhu", null, feedbackPreferences);
         List<Member> memberList = List.of(dummyMember);
 
         when(teamService.getTeam(teamId)).thenReturn(dummyTeam);
@@ -133,7 +137,8 @@ class TeamControllerTest {
         Long teamId = 3L;
         Long memberId = 4L;
 
-        Member dummyMember = new Member("hehe", "hoho", null);
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member dummyMember = new Member("hehe", "hoho", null, feedbackPreferences);
         List<Member> memberList = List.of(dummyMember);
 
         when(memberService.getMembersByTeam(memberId, teamId)).thenReturn(memberList);

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/domain/TeamTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/domain/TeamTest.java
@@ -1,6 +1,7 @@
 package com.feedhanjum.back_end.team.domain;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,7 +21,8 @@ class TeamTest {
     private final AtomicLong nextId = new AtomicLong(1L);
 
     private Member createMember(String name) {
-        Member member = new Member(name, name + "@email.com", new ProfileImage("blue", "default.png"));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member member = new Member(name, name + "@email.com", new ProfileImage("blue", "default.png"), feedbackPreferences);
         ReflectionTestUtils.setField(member, "id", nextId.getAndIncrement());
         return member;
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
@@ -2,6 +2,7 @@ package com.feedhanjum.back_end.team.service;
 
 import com.feedhanjum.back_end.event.EventPublisher;
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
@@ -63,7 +64,8 @@ class TeamServiceTest {
         Long userId = 1L;
         when(clock.instant()).thenReturn(LocalDate.of(2023, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
         when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
-        Member leader = new Member("haha", "haha@hoho", new ProfileImage("blue", "image1"));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        Member leader = new Member("haha", "haha@hoho", new ProfileImage("blue", "image1"), feedbackPreferences);
         Team team = new Team("haha", leader, LocalDate.now(clock).plusDays(1), LocalDate.now(clock).plusDays(10), FeedbackType.ANONYMOUS);
         when(teamQueryRepository.findTeamByMemberId(userId)).thenReturn(List.of(team));
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/util/DomainTestUtils.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/util/DomainTestUtils.java
@@ -1,19 +1,22 @@
 package com.feedhanjum.back_end.util;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.team.domain.Team;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DomainTestUtils {
     private static final AtomicLong nextId = new AtomicLong(1);
 
     public static Member createMemberWithoutId(String name) {
-        return new Member(name, name + "email@com", new ProfileImage("red", "default.png"));
+        List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
+        return new Member(name, name + "email@com", new ProfileImage("red", "default.png"), feedbackPreferences);
     }
 
     public static Member createMemberWithId(String name) {


### PR DESCRIPTION
# 관련 이슈
FD-103
FD-312

# 변경된 점
- [x] 피드백 선호 정보 조회 로직 추가
- [x] 피드백 선호 정보 수정 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
  • Members now have the option to set and update their feedback preferences during registration and via new profile management endpoints, enabling a more personalized experience.  
  • New endpoints added for retrieving and changing member feedback preferences.  

- **Documentation**  
  • Enhanced API documentation provides clearer descriptions of member profile data, ensuring improved transparency and ease of integration.  
  • New DTOs introduced for member feedback preferences, improving data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->