### PR TITLE
[FD-186] feat: 메인페이지에 전역상태 반영 및 바텀시트 연결

### DIFF
--- a/front-end/src/api/useAuth.js
+++ b/front-end/src/api/useAuth.js
@@ -31,10 +31,3 @@ export const useLogin = () => {
     },
   });
 };
-
-export const useMyTeams = () => {
-  return useQuery({
-    queryKey: ['myTeams'],
-    queryFn: () => api.get({ url: '/api/team/my-teams2' }),
-  });
-};

--- a/front-end/src/api/useMainPage.js
+++ b/front-end/src/api/useMainPage.js
@@ -7,7 +7,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 export const useMyTeams = () => {
   return useQuery({
     queryKey: ['myTeams'],
-    queryFn: () => api.get({ url: '/api/team/my-teams' }),
+    queryFn: () => api.get({ url: '/api/team/my-teams2' }),
   });
 };
 

--- a/front-end/src/api/useMainPage.js
+++ b/front-end/src/api/useMainPage.js
@@ -19,6 +19,7 @@ export const useMainCard = (teamId) => {
   return useQuery({
     queryKey: ['mainCard', teamId],
     queryFn: () => api.get({ url: `/recentSchedule/${teamId}` }), // 임시
+    enabled: !!teamId,
   });
 };
 
@@ -30,6 +31,7 @@ export const useMainCard2 = (teamId) => {
   return useQuery({
     queryKey: ['mainCard2', teamId],
     queryFn: () => api.get({ url: `/api/team/${teamId}/members` }),
+    enabled: !!teamId,
   });
 };
 
@@ -42,6 +44,7 @@ export const useNotification = (teamId) => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['notification', teamId],
     queryFn: () => api.get({ url: '/api/notification' }),
+    enabled: !!teamId,
   });
 
   const markAsReadMutation = useMutation({

--- a/front-end/src/api/useMainPage.js
+++ b/front-end/src/api/useMainPage.js
@@ -18,7 +18,7 @@ export const useMyTeams = () => {
 export const useMainCard = (teamId) => {
   return useQuery({
     queryKey: ['mainCard', teamId],
-    queryFn: () => api.get({ url: `/recentSchedule/${teamId}` }), // 임시
+    queryFn: () => api.get({ url: `/api/team/${teamId}/schedule` }), // 임시
     enabled: !!teamId,
   });
 };

--- a/front-end/src/components/Accordion.jsx
+++ b/front-end/src/components/Accordion.jsx
@@ -9,6 +9,9 @@ import Icon from './Icon';
  * @param {number} props.selectedTeamId - 선택된 팀 ID
  * @param {array} props.teamList - 팀 목록
  * @param {function} props.onTeamClick - 팀 클릭 시 호출되는 함수
+ * @param {boolean} props.isAlarmRead - 알람 읽음 여부
+ * @param {boolean} props.canClose - 닫기 버튼 여부
+ * @param {function} props.onClickLastButton - 마지막 버튼 클릭 시 호출되는 함수
  * @returns
  */
 export default function Accordion({

--- a/front-end/src/mocks/handlers.js
+++ b/front-end/src/mocks/handlers.js
@@ -10,7 +10,7 @@ export const handlers = [
   }),
 
   // 메인 카드 조회
-  http.get(`${BASE_URL}/recentSchedule/:teamId`, () => {
+  http.get(`${BASE_URL}/api/team/:teamId/schedule`, () => {
     return HttpResponse.json(schedules[0]);
   }),
 

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -10,7 +10,7 @@ import { checkIsFinished, timeInPeriod } from '../../utility/time';
 import { ScheduleActionType } from './components/ScheduleAction';
 import ScheduleAction from './components/ScheduleAction';
 import { useGetSchedules } from '../../api/useCalendar';
-import { useMyTeams } from '../../api/useAuth';
+import { useMyTeams } from '../../api/useMainPage';
 import { useTeam } from '../../useTeam';
 
 export default function Calendar() {

--- a/front-end/src/pages/main/components/MainCard.jsx
+++ b/front-end/src/pages/main/components/MainCard.jsx
@@ -14,7 +14,7 @@ export const cardType = Object.freeze({
 /**
  * 메인 카드 컴포넌트
  * @param {object} props
- * @param {keyof cardType} props.type - 메인 카드 타입
+ * @param {boolean} props.isInTeam - 팀에 속해있는지 여부
  * @param {object} props.recentSchedule - 최신 스케줄
  * @param {number} props.scheduleDifferece - D-day
  * @param {function} props.onClickMainButton - 메인 버튼 클릭 이벤트
@@ -23,9 +23,9 @@ export const cardType = Object.freeze({
  * @returns {ReactElement}
  */
 export default function MainCard({
-  type = cardType.DEFUALT,
+  isInTeam,
   recentSchedule,
-  scheduleDifferece = 0,
+  scheduleDifferece,
   onClickMainButton,
   onClickSubButton,
   onClickChevronButton,
@@ -41,7 +41,7 @@ export default function MainCard({
     }
   }, [isOpen]);
 
-  if (type === cardType.ADD_TEAM) {
+  if (!isInTeam) {
     // 팀에 속하지 않은 경우 무조건 팀 만들어야 함
     return (
       <MainCardFrame>
@@ -58,7 +58,7 @@ export default function MainCard({
   }
 
   // 마지막 일정이 끝난지 24시간이 넘은 경우 -> response 자체가 없음
-  if (type === cardType.ADD_SCHEDULE) {
+  if (!scheduleDifferece) {
     return (
       <MainCardFrame>
         <p className='body-1 mt-11 mb-10 text-center text-gray-300'>
@@ -77,7 +77,7 @@ export default function MainCard({
   }
 
   // 마지막 일정이 끝난 후 24시간이 안된 경우: response 있음 && timeDiff가 0보다 작거나 같음
-  if (type === cardType.END_SCHEDULE) {
+  if (scheduleDifferece <= 0) {
     return (
       <MainCardFrame>
         <div className='flex flex-col items-center justify-center'>

--- a/front-end/src/pages/main/components/MainCard.jsx
+++ b/front-end/src/pages/main/components/MainCard.jsx
@@ -4,19 +4,28 @@ import Icon from '../../../components/Icon';
 import MediumButton from '../../../components/buttons/MediumButton';
 import { useEffect, useRef, useState } from 'react';
 
+export const cardType = Object.freeze({
+  ADD_TEAM: 'ADD_TEAM',
+  ADD_SCHEDULE: 'ADD_SCHEDULE',
+  END_SCHEDULE: 'END_SCHEDULE',
+  DEFUALT: 'DEFAULT',
+});
+
 /**
  * 메인 카드 컴포넌트
  * @param {object} props
- * @param {boolean} props.isInTeam - 팀에 속해있는지 여부
+ * @param {keyof cardType} props.type - 메인 카드 타입
  * @param {object} props.recentSchedule - 최신 스케줄
+ * @param {number} props.scheduleDifferece - D-day
  * @param {function} props.onClickMainButton - 메인 버튼 클릭 이벤트
  * @param {function} props.onClickSubButton - 서브 버튼 클릭 이벤트
  * @param {function} props.onClickChevronButton - 체크론 버튼 클릭 이벤트
  * @returns {ReactElement}
  */
 export default function MainCard({
-  isInTeam = true,
+  type = cardType.DEFUALT,
   recentSchedule,
+  scheduleDifferece = 0,
   onClickMainButton,
   onClickSubButton,
   onClickChevronButton,
@@ -32,7 +41,7 @@ export default function MainCard({
     }
   }, [isOpen]);
 
-  if (!isInTeam) {
+  if (type === cardType.ADD_TEAM) {
     // 팀에 속하지 않은 경우 무조건 팀 만들어야 함
     return (
       <MainCardFrame>
@@ -49,7 +58,7 @@ export default function MainCard({
   }
 
   // 마지막 일정이 끝난지 24시간이 넘은 경우 -> response 자체가 없음
-  if (!recentSchedule) {
+  if (type === cardType.ADD_SCHEDULE) {
     return (
       <MainCardFrame>
         <p className='body-1 mt-11 mb-10 text-center text-gray-300'>
@@ -67,10 +76,8 @@ export default function MainCard({
     );
   }
 
-  const scheduleDifferece = getScheduleTimeDiff(recentSchedule);
-
   // 마지막 일정이 끝난 후 24시간이 안된 경우: response 있음 && timeDiff가 0보다 작거나 같음
-  if (scheduleDifferece <= 0) {
+  if (type === cardType.END_SCHEDULE) {
     return (
       <MainCardFrame>
         <div className='flex flex-col items-center justify-center'>
@@ -97,7 +104,7 @@ export default function MainCard({
       <MainCardFrame>
         {renderTitle(recentSchedule, scheduleDifferece)}
         <hr className='my-6 w-full border-gray-500' />
-        {renderMyRole(recentSchedule)}
+        {renderMyRole(recentSchedule, onClickMainButton)}
         {renderTeamRole(recentSchedule, contentRef, height)}
         <MediumButton
           text={
@@ -126,25 +133,6 @@ function MainCardFrame({ children }) {
   );
 }
 
-function getScheduleTimeDiff(recentSchedule) {
-  const todayTime = new Date();
-  const startTime = new Date(recentSchedule.startTime);
-  const endTime = new Date(recentSchedule.endTime);
-
-  if (Math.abs(startTime - todayTime) < Math.abs(endTime - todayTime)) {
-    // 미래 일정인 경우, today를 자정으로 설정하여 계산
-    todayTime.setHours(0, 0, 0, 0);
-
-    const diffDay = Math.floor((startTime - todayTime) / (1000 * 60 * 60 * 24));
-
-    if (diffDay === 0) return 'DAY';
-    return diffDay;
-  } else {
-    // 과거 일정인 경우
-    return Math.ceil((endTime - todayTime) / (1000 * 60 * 60 * 24));
-  }
-}
-
 function renderTitle(recentSchedule, scheduleDifferece) {
   return (
     <div className='flex flex-col items-center justify-center pt-6'>
@@ -161,7 +149,7 @@ function renderTitle(recentSchedule, scheduleDifferece) {
   );
 }
 
-function renderMyRole(recentSchedule) {
+function renderMyRole(recentSchedule, onButtonClick) {
   return recentSchedule.roles.find((role) => role.memberId === 1) ?
       <div className='flex flex-col gap-3'>
         <Tag type={TagType.MY_ROLE} />
@@ -179,7 +167,11 @@ function renderMyRole(recentSchedule) {
         <p className='body-1 text-center text-gray-400'>
           나의 역할이 비어있어요
         </p>
-        <MediumButton text={'나의 역할 추가하기'} isOutlined={false} />
+        <MediumButton
+          text={'나의 역할 추가하기'}
+          isOutlined={false}
+          onClick={onButtonClick}
+        />
       </div>;
 }
 

--- a/front-end/src/pages/main/components/MainCard.jsx
+++ b/front-end/src/pages/main/components/MainCard.jsx
@@ -4,13 +4,6 @@ import Icon from '../../../components/Icon';
 import MediumButton from '../../../components/buttons/MediumButton';
 import { useEffect, useRef, useState } from 'react';
 
-export const cardType = Object.freeze({
-  ADD_TEAM: 'ADD_TEAM',
-  ADD_SCHEDULE: 'ADD_SCHEDULE',
-  END_SCHEDULE: 'END_SCHEDULE',
-  DEFUALT: 'DEFAULT',
-});
-
 /**
  * 메인 카드 컴포넌트
  * @param {object} props

--- a/front-end/src/pages/teamspace/TeamSpaceList.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceList.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useMyTeams } from '../../api/useAuth';
+import { useMyTeams } from '../../api/useMainPage';
 import NavBar2 from '../../components/NavBar2';
 import StickyWrapper from '../../components/wrappers/StickyWrapper';
 import { useNavigate } from 'react-router-dom';

--- a/front-end/src/useTeam.jsx
+++ b/front-end/src/useTeam.jsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useMyTeams } from './api/useMainPage';
 import { useTeamContext } from './TeamContext';
 
 // 팀 관련 로직을 처리하는 커스텀 훅
@@ -15,6 +17,15 @@ export const useTeam = () => {
       dispatch({ type: 'SELECT_TEAM', payload: teamId });
     }
   };
+
+  // useTeam 호출하면 팀 목록을 가져옴
+  const { data: teamsData } = useMyTeams();
+
+  useEffect(() => {
+    if (teamsData) {
+      setTeams(teamsData);
+    }
+  }, [teamsData]);
 
   return {
     teams: state.teams,

--- a/front-end/src/utility/time.js
+++ b/front-end/src/utility/time.js
@@ -130,3 +130,27 @@ export function timePickerToDate(date, time) {
     minute,
   );
 }
+
+/**
+ * D-day 계산하는 함수
+ * @param {object} recentSchedule
+ * @returns
+ */
+export function getScheduleTimeDiff(recentSchedule) {
+  const todayTime = new Date();
+  const startTime = new Date(recentSchedule.startTime);
+  const endTime = new Date(recentSchedule.endTime);
+
+  if (Math.abs(startTime - todayTime) < Math.abs(endTime - todayTime)) {
+    // 미래 일정인 경우, today를 자정으로 설정하여 계산
+    todayTime.setHours(0, 0, 0, 0);
+
+    const diffDay = Math.floor((startTime - todayTime) / (1000 * 60 * 60 * 24));
+
+    if (diffDay === 0) return 'DAY';
+    return diffDay;
+  } else {
+    // 과거 일정인 경우
+    return Math.ceil((endTime - todayTime) / (1000 * 60 * 60 * 24));
+  }
+}


### PR DESCRIPTION
- 메인페이지 컴포넌트에서 계산하고 ui 분기
- 아코디언에서 팀스페이스 조회 및 선택
- 메인카드, 알림 등 상태 동기화 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Main page now dynamically adjusts card displays and actions based on current scheduling data.
	- Schedule timing is calculated more accurately for clearer user guidance.
	- Data fetching is optimized to run only when a valid team is selected, enhancing performance and error handling.
	- Accordion component enhanced with new props for alarm status and close button functionality.
	- New functionality added to the `useTeam` hook for improved team data fetching.

- **Bug Fixes**
	- Resolved issues with the handling of team data and scheduling logic to improve user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->