### PR TITLE
[FD-318] 피드백 선호도 설정 화면 개발

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -23,6 +23,7 @@ import FeedbackComplete from './pages/feedback/FeedbackComplete';
 import FeedbackSelf from './pages/feedback/FeedbackSelf';
 import SelfFeedback from './pages/mypage/SelfFeedback';
 import { TeamProvider } from './TeamContext';
+import FeedbackFavorite from './pages/feedback/FeedbackFavorite';
 
 const queryClient = new QueryClient();
 
@@ -38,6 +39,7 @@ export default function App() {
                 <Route path='request' element={<FeedbackRequest />} />
                 <Route path='self' element={<FeedbackSelf />} />
                 <Route path='complete' element={<FeedbackComplete />} />
+                <Route path='favorite' element={<FeedbackFavorite />} />
                 <Route path='received/:userId' element={<FeedbackReceived />} />
                 <Route path='sent/:userId' element={<FeedbackSent />} />
               </Route>

--- a/front-end/src/api/useAuth.js
+++ b/front-end/src/api/useAuth.js
@@ -11,9 +11,12 @@ export const useVerify = () => {
   });
 };
 
-export const useSignUp = () => {
+export const useSignUp = (afterSuccess) => {
   return useMutation({
     mutationFn: (data) => api.post({ url: '/api/auth/signup', body: data }),
+    onSuccess: () => {
+      afterSuccess();
+    },
   });
 };
 

--- a/front-end/src/api/useFeedback.js
+++ b/front-end/src/api/useFeedback.js
@@ -77,3 +77,16 @@ export const useFeedbackFavorite = () => {
     queryFn: () => api.get({ url: '/api/feedbacks/favorite' }),
   });
 };
+
+export const useEditFavorite = (afterSuccess) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data) =>
+      api.post({ url: '/api/member/feedback-prefer', body: data }),
+    onSuccess: () => {
+      // TODO: 사용자 선호 피드백 정보 조회할때 캐시를 지우도록 수정
+      // queryClient.invalidateQueries({ queryKey: ['feedback-favorite'] });
+      afterSuccess();
+    },
+  });
+};

--- a/front-end/src/api/useFeedback.js
+++ b/front-end/src/api/useFeedback.js
@@ -70,3 +70,10 @@ export const useFeedbackLikeCancel = (userId, feedbackId) => {
     },
   });
 };
+
+export const useFeedbackFavorite = () => {
+  return useQuery({
+    queryKey: ['feedback-favorite'],
+    queryFn: () => api.get({ url: '/api/feedbacks/favorite' }),
+  });
+};

--- a/front-end/src/components/buttons/KeywordButton.jsx
+++ b/front-end/src/components/buttons/KeywordButton.jsx
@@ -10,7 +10,7 @@ export default function KeywordButton({ isActive, onClick, children }) {
     <button
       className={`rounded-200 size-fit bg-gray-800 px-3 py-1.5 ${
         isActive ?
-          'body-2 border border-lime-200/60 text-lime-500'
+          'body-2 text-lime-500 ring ring-lime-200/60'
         : 'body-1 text-gray-300'
       }`}
       onClick={onClick}

--- a/front-end/src/components/buttons/KeywordButton.jsx
+++ b/front-end/src/components/buttons/KeywordButton.jsx
@@ -8,7 +8,7 @@
 export default function KeywordButton({ isActive, onClick, children }) {
   return (
     <button
-      className={`rounded-200 size-fit bg-gray-800 px-3 py-1.5 ${
+      className={`rounded-200 size-fit bg-gray-800 px-3 py-1.5 transition duration-300 ${
         isActive ?
           'body-2 text-lime-500 ring ring-lime-200/60'
         : 'body-1 text-gray-300'

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -52,7 +52,7 @@ button {
   cursor: pointer;
 }
 
-button:active {
+.classic:active {
   opacity: 0.8;
 }
 

--- a/front-end/src/mocks/handlers.js
+++ b/front-end/src/mocks/handlers.js
@@ -58,4 +58,34 @@ export const handlers = [
 
     return HttpResponse.json(data, { status: 201 });
   }),
+
+  // 피드백 키워드 조회
+  http.get(`${BASE_URL}/api/feedbacks/favorite`, () => {
+    return HttpResponse.json([
+      {
+        스타일: [
+          '완곡하게',
+          '솔직하게',
+          '칭찬과 함께',
+          '가볍게',
+          '간단하게',
+          '신중하게',
+          '유머러스한',
+          '구체적인',
+        ],
+      },
+      {
+        내용: [
+          '명확한',
+          '현실적인',
+          '대안을 제시하는',
+          '핵심적인',
+          '발전적인',
+          '이상적인',
+          '색다른',
+          '논리적인',
+        ],
+      },
+    ]);
+  }),
 ];

--- a/front-end/src/mocks/handlers.js
+++ b/front-end/src/mocks/handlers.js
@@ -88,4 +88,27 @@ export const handlers = [
       },
     ]);
   }),
+
+  // 회원가입
+  http.post(`${BASE_URL}/api/auth/signup`, async ({ request }) => {
+    const data = await request.json();
+
+    console.log('서버에 도착한 정보: ', data);
+
+    // 2초 딜레이 추가
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return HttpResponse.json(data, { status: 201 });
+  }),
+
+  // 피드백 선호 수정
+  http.post(`${BASE_URL}/api/member/feedback-prefer`, async ({ request }) => {
+    const data = await request.json();
+
+    console.log('서버에 도착한 정보: ', data);
+    // 2초 딜레이 추가
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return HttpResponse.json(data, { status: 201 });
+  }),
 ];

--- a/front-end/src/pages/feedback/FeedbackFavorite.jsx
+++ b/front-end/src/pages/feedback/FeedbackFavorite.jsx
@@ -94,7 +94,7 @@ export default function FeedbackFavorite() {
       <FooterWrapper>
         <LargeButton
           isOutlined={false}
-          text={mutation.isPending ? '로딩중' : '보내기'} // 로딩 중일 때 버튼 텍스트 변경... 추후 수정 필요
+          text={mutation.isPending ? '로딩중' : '완료'} // 로딩 중일 때 버튼 텍스트 변경... 추후 수정 필요
           disabled={selectedStyle.length === 0 && selectedContent.length === 0}
           onClick={onFinish}
         />

--- a/front-end/src/pages/feedback/FeedbackFavorite.jsx
+++ b/front-end/src/pages/feedback/FeedbackFavorite.jsx
@@ -1,0 +1,90 @@
+import { useLocation } from 'react-router-dom';
+import NavBar from '../auth/components/NavBar';
+import Tag, { TagType } from '../../components/Tag';
+import KeywordButton from '../../components/buttons/KeywordButton';
+import { useFeedbackFavorite } from '../../api/useFeedback';
+import { useEffect, useState } from 'react';
+import FooterWrapper from '../../components/wrappers/FooterWrapper';
+import LargeButton from '../../components/buttons/LargeButton';
+import { use } from 'react';
+
+export default function FeedbackFavorite() {
+  const location = useLocation();
+  const process = new URLSearchParams(location.search).get('process');
+
+  const [selectedStyle, setSelectedStyle] = useState([]);
+  const [selectedContent, setSelectedContent] = useState([]);
+
+  const { data } = useFeedbackFavorite();
+
+  // mutate의 onSuccess에 라우팅 메서드 전달
+  // const mutation = use회원가입(navigate('/main'));
+
+  const onKeywordButtonClick = (isStyle, keyword) => {
+    const keywords = isStyle ? selectedStyle : selectedContent;
+    const setKeywords = isStyle ? setSelectedStyle : setSelectedContent;
+    keywords.find((k) => k == keyword) ?
+      setKeywords([...keywords.filter((item) => item !== keyword)])
+    : keywords.length < 2 && setKeywords([...keywords, keyword]);
+  };
+
+  return (
+    <div className='flex size-full flex-col'>
+      {process === 'signup' && (
+        <h1 className='header-2 text-gray-0 pt-10 pb-3 whitespace-pre-line'>
+          {'선호하는 피드백 유형을\n선택해 주세요'}
+        </h1>
+      )}
+      <p className='body-1 text-gray-200'>
+        카테고리별 최대 2개까지 선택해 주세요
+      </p>
+      {data && (
+        <div className='mt-10 flex flex-col'>
+          <h2 className='subtitle-1 text-gray-0 mb-3'>스타일</h2>
+          <div className='flex flex-wrap gap-2'>
+            {data[0]['스타일'].map((keyword, index) => (
+              <KeywordButton
+                type={TagType.KEYWORD}
+                key={index}
+                isActive={selectedStyle.includes(keyword)}
+                onClick={() => onKeywordButtonClick(true, keyword)}
+              >
+                {keyword}
+              </KeywordButton>
+            ))}
+          </div>
+          <div className='h-8' />
+          <h2 className='subtitle-1 text-gray-0 mb-3'>내용</h2>
+          <div className='flex flex-wrap gap-2'>
+            {data[1]['내용'].map((keyword, index) => (
+              <KeywordButton
+                type={TagType.KEYWORD}
+                key={index}
+                isActive={selectedContent.includes(keyword)}
+                onClick={() => onKeywordButtonClick(false, keyword)}
+              >
+                {keyword}
+              </KeywordButton>
+            ))}
+          </div>
+        </div>
+      )}
+      <FooterWrapper>
+        <LargeButton
+          isOutlined={false}
+          text={'완료'} // 로딩 중일 때 버튼 텍스트 변경... 추후 수정 필요
+          disabled={selectedStyle.length === 0 && selectedContent.length === 0}
+          onClick={() => {
+            mutation.mutate({
+              email: location.state.email,
+              password: location.state.password,
+              name: location.state,
+              profileImage: location.state.profileImage,
+              feedbackPreference: [...selectedStyle, ...selectedContent],
+            });
+          }}
+        />
+      </FooterWrapper>
+    </div>
+  );
+}


### PR DESCRIPTION

<img width="391" alt="image" src="https://github.com/user-attachments/assets/c436dee6-21eb-430e-b4d7-d7e95773eed5" />

### 피드백 선호도 설정 화면
- url query prameter 확인하여, `/feedback/favorite?process=signup` 인 경우와 아닌 경우를 구분
- signup 플로우인 경우, 현재까지 받아온 url state 포함하여 회원가입 post
- 아닌 경우, 피드백 선호 키워드 변경 post

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated page within the feedback section where users can view and manage their favorite feedback items.
  - Improved user interactions during signup and feedback editing with immediate visual updates and navigational feedback.
  - Enabled retrieval and modification of feedback preferences to enhance personalization.

- **Style**
  - Refined interactive button transitions and active state effects for a smoother and more responsive interface experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->