### PR TITLE
[FD-320]  팀 조회 api에 가장 빠른 일정 시작 시간 및 가장 늦은 일정 종료 시간 추가

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/AuthInterceptor.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/infra/AuthInterceptor.java
@@ -12,7 +12,11 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class AuthInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return true; // OPTIONS 요청은 인증 검사 없이 통과
+        }
         HttpSession session = request.getSession(false);
+
         if (session != null && session.getAttribute(SessionConst.MEMBER_ID) != null) {
             return true;
         }

--- a/back-end/src/main/java/com/feedhanjum/back_end/core/exception/FindControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/exception/FindControllerAdvice.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,4 +26,12 @@ public class FindControllerAdvice {
         errors.put("message", e.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errors);
     }
+    
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNoResourceFoundException(NoResourceFoundException e) {
+        Map<String, String> errors = new HashMap<>();
+        errors.put("message", "Resource not found " + e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errors);
+    }
+    
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleQueryRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleQueryRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.feedhanjum.back_end.member.domain.QMember.member;
 import static com.feedhanjum.back_end.schedule.domain.QSchedule.schedule;
@@ -54,7 +55,7 @@ public class ScheduleQueryRepository {
                 .fetch();
     }
 
-    
+
     public List<ScheduleProjectionDto> findSchedulesByTeamIdAndDuration(Long memberId, Long teamId, LocalDateTime startTime, LocalDateTime endTime) {
         JPQLQuery<Long> subQuery = JPAExpressions
                 .select(team.id)
@@ -67,6 +68,21 @@ public class ScheduleQueryRepository {
                 .fetch();
     }
 
+    public Optional<LocalDateTime> findEarliestStartTimeByTeamId(Long teamId) {
+        return Optional.ofNullable(queryFactory.select(schedule.startTime)
+                .from(schedule)
+                .where(teamIdEq(teamId))
+                .orderBy(schedule.startTime.asc())
+                .fetchOne());
+    }
+
+    public Optional<LocalDateTime> findLatestEndTimeByTeamId(Long teamId){
+        return Optional.ofNullable(queryFactory.select(schedule.endTime)
+                .from(schedule)
+                .where(teamIdEq(teamId))
+                .orderBy(schedule.endTime.desc())
+                .fetchOne());
+    }
 
 
     private BooleanExpression memberIdEq(Long memberId) {
@@ -77,7 +93,7 @@ public class ScheduleQueryRepository {
         return teamId == null ? null : team.id.eq(teamId);
     }
 
-    private JPAQuery<ScheduleProjectionDto> queryScheduleProjectionDto(){
+    private JPAQuery<ScheduleProjectionDto> queryScheduleProjectionDto() {
         return queryFactory.select(Projections.constructor(
                         ScheduleProjectionDto.class,
                         team.id,

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
@@ -175,6 +175,16 @@ public class ScheduleService {
         jobRecordRepository.save(jobRecord);
     }
 
+    @Transactional(readOnly = true)
+    public LocalDateTime getEarliestScheduleStartTime(Long teamId) {
+        return scheduleQueryRepository.findEarliestStartTimeByTeamId(teamId).orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public LocalDateTime getLatestEndTime(Long teamId) {
+        return scheduleQueryRepository.findLatestEndTimeByTeamId(teamId).orElse(null);
+    }
+
     private List<ScheduleNestedDto> getScheduleNestedDtos(List<ScheduleProjectionDto> schedules) {
         Map<Long, ScheduleNestedDto> scheduleNestedDtoMap = new HashMap<>();
         Map<Long, ScheduleMemberNestedDto> scheduleMemberNestedDtoMap = new HashMap<>();
@@ -255,4 +265,5 @@ public class ScheduleService {
         if (scheduleRepository.findByTeamIdAndStartTime(teamId, requestDto.startTime()).isPresent())
             throw new ScheduleAlreadyExistException("이미 같은 시작시간에 일정이 있습니다.");
     }
+
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -3,6 +3,7 @@ package com.feedhanjum.back_end.team.controller;
 import com.feedhanjum.back_end.auth.infra.Login;
 import com.feedhanjum.back_end.member.controller.dto.MemberDto;
 import com.feedhanjum.back_end.member.service.MemberService;
+import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.team.controller.dto.*;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamJoinToken;
@@ -19,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,6 +30,7 @@ import java.util.stream.Collectors;
 public class TeamController {
     private final TeamService teamService;
     private final MemberService memberService;
+    private final ScheduleService scheduleService;
 
     @Operation(summary = "팀 생성", description = "로그인한 사용자를 팀장으로 하는 팀을 생성한다.")
     @ApiResponses({
@@ -71,7 +74,11 @@ public class TeamController {
         Team team = teamService.getTeam(teamId);
         List<MemberDto> membersByTeam = memberService.getMembersByTeam(memberId, teamId)
                 .stream().map(MemberDto::new).toList();
+        LocalDateTime earliestStartTime = scheduleService.getEarliestScheduleStartTime(teamId);
+        LocalDateTime latestEndTime = scheduleService.getLatestEndTime(teamId);
         TeamDetailResponse teamDetailResponse = new TeamDetailResponse();
+        teamDetailResponse.setEarliestScheduleStartTime(earliestStartTime);
+        teamDetailResponse.setLatestScheduleEndTime(latestEndTime);
         teamDetailResponse.setTeamResponse(new TeamResponse(team));
         teamDetailResponse.setMembers(membersByTeam);
         return ResponseEntity.ok(teamDetailResponse);

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamDetailResponse.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamDetailResponse.java
@@ -12,10 +12,10 @@ public class TeamDetailResponse {
     @Schema(description = "팀 응답 정보")
     private TeamResponse teamResponse;
 
-    @Schema(description = "일정의 가장 빠른 시작 시간")
+    @Schema(description = "일정의 가장 빠른 시작 시간. null일 경우, 일정이 존재하지 않음")
     private LocalDateTime earliestScheduleStartTime;
 
-    @Schema(description = "일정의 가장 늦은 종료 시간")
+    @Schema(description = "일정의 가장 늦은 종료 시간. null일 경우, 일정이 존재하지 않음")
     private LocalDateTime latestScheduleEndTime;
 
     @Schema(description = "팀 멤버 목록")

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamDetailResponse.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamDetailResponse.java
@@ -4,12 +4,20 @@ import com.feedhanjum.back_end.member.controller.dto.MemberDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
 public class TeamDetailResponse {
     @Schema(description = "팀 응답 정보")
     private TeamResponse teamResponse;
+
+    @Schema(description = "일정의 가장 빠른 시작 시간")
+    private LocalDateTime earliestScheduleStartTime;
+
+    @Schema(description = "일정의 가장 늦은 종료 시간")
+    private LocalDateTime latestScheduleEndTime;
+
     @Schema(description = "팀 멤버 목록")
     private List<MemberDto> members;
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
@@ -5,6 +5,7 @@ import com.feedhanjum.back_end.member.controller.dto.MemberDto;
 import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.service.MemberService;
+import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.team.controller.dto.TeamCreateRequest;
 import com.feedhanjum.back_end.team.controller.dto.TeamDetailResponse;
 import com.feedhanjum.back_end.team.controller.dto.TeamResponse;
@@ -36,6 +37,9 @@ class TeamControllerTest {
 
     @Mock
     private MemberService memberService;
+
+    @Mock
+    private ScheduleService scheduleService;
 
     @InjectMocks
     private TeamController teamController;


### PR DESCRIPTION
# 관련 이슈
FD-320

# 변경된 점
- [x] 팀 상세 정보 조회 응답에 해당 팀의 가장 빠른 일정 시작 시간 및 가장 늦은 일정 종료 시간 추가
    - 팀의 존재 기간을 변경할 시, 검증 로직 용도로 사용함