### PR TITLE
[FD-182] 팀스페이스 생성 api 적용

### DIFF
--- a/front-end/src/api/useTeamspace.js
+++ b/front-end/src/api/useTeamspace.js
@@ -34,6 +34,19 @@ export const useKickMember = (teamId) => {
   });
 };
 
+export const useMakeTeam = () => {
+  return useMutation({
+    mutationFn: (teamInfo) => {
+      const sendingData = teamInfo;
+      return api.post({ url: `/api/team/create`, body: sendingData });
+    },
+    onSuccess: (data) => {
+      console.log(data);
+      return data;
+    },
+  });
+};
+
 export const useEditTeam = (teamId) => {
   return useMutation({
     mutationFn: (teamInfo) => {
@@ -48,5 +61,14 @@ export const useDeleteTeam = (teamId) => {
     mutationFn: () => {
       return api.delete({ url: `/api/team/${teamId}/leave` });
     },
+  });
+};
+
+export const useInviteTeam = () => {
+  return useMutation({
+    mutationFn: (teamId) => {
+      return api.post({ url: `/api/team/${teamId}/join-token` });
+    },
+    onSuccess: (data) => data,
   });
 };

--- a/front-end/src/mocks/handlers2.js
+++ b/front-end/src/mocks/handlers2.js
@@ -105,9 +105,9 @@ export const handlers2 = [
   }),
 
   // 팀 수정
-  http.post(`${BASE_URL}/api/team/:teamId`, () => {
-    return HttpResponse.json(teamResponse);
-  }),
+  // http.post(`${BASE_URL}/api/team/:teamId`, () => {
+  //   return HttpResponse.json(teamResponse);
+  // }),
 
   // 팀 삭제
   http.delete(`${BASE_URL}/api/team/:teamId/leave`, () => {

--- a/front-end/src/pages/teamspace/TeamSpaceMake.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceMake.jsx
@@ -11,6 +11,7 @@ import { checkTeamSpaceMakingInfo } from '../../utility/inputChecker';
 import CustomDatePicker, {
   DatePickerDropdown,
 } from '../../components/CustomDatePicker';
+import { useMakeTeam } from '../../api/useTeamspace';
 
 /**
  * @param {object} props
@@ -25,16 +26,31 @@ export default function TeamSpaceMake({ isFirst = false }) {
   const [isDatePickerOpen1, setIsDatePickerOpen1] = useState(false);
   const [isDatePickerOpen2, setIsDatePickerOpen2] = useState(false);
   const navigate = useNavigate();
+  const { mutate: makeTeam } = useMakeTeam();
 
   const onClickNext = () => {
     if (!checkTeamSpaceMakingInfo(teamSpaceName, startDate, endDate)) {
       return;
     } else {
-      //TODO: 팀 공간 만들기 요청
+      makeTeam(
+        {
+          name: teamSpaceName,
+          startDate: startDate,
+          endDate: endDate,
+          feedbackType: isAnonymous ? 'ANONYMOUS' : 'IDENTIFIED',
+        },
+        {
+          onSuccess: (teamData) => {
+            navigate(`/teamspace/make/success?teamName=${teamSpaceName}`, {
+              state:
+                isFirst ?
+                  { from: '/first', teamId: teamData.id }
+                : { from: '/', teamId: teamData.id },
+            });
+          },
+        },
+      );
     }
-    navigate(`/teamspace/make/success?teamName=${teamSpaceName}`, {
-      state: isFirst ? { from: '/first' } : { from: '/' },
-    });
   };
 
   const onClickPop = () => {
@@ -128,8 +144,9 @@ export default function TeamSpaceMake({ isFirst = false }) {
             className={
               'rounded-300 flex h-[56px] w-full items-center justify-center px-4 py-2 text-gray-300'
             }
+            onClick={() => navigate('/main')}
           >
-            <a>건너뛰기</a>
+            <a>나중에 만들기</a>
           </div>
         )}
       </div>

--- a/front-end/src/pages/teamspace/TeamSpaceMakeSuccess.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceMakeSuccess.jsx
@@ -1,12 +1,16 @@
 import NavBar from '../auth/components/NavBar';
 import LargeButton from '../../components/buttons/LargeButton';
 import { showToast } from '../../utility/handleToast';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useInviteTeam } from '../../api/useTeamspace';
 
 export default function TeamSpaceMakeSuccess() {
   const [searchParams] = useSearchParams();
   const location = useLocation();
   const teamName = searchParams.get('teamName');
+  const navigate = useNavigate();
+
+  const { mutate: inviteTeam } = useInviteTeam();
 
   return (
     <div className='relative flex h-dvh w-full flex-col justify-start'>
@@ -21,8 +25,16 @@ export default function TeamSpaceMakeSuccess() {
           text='초대링크 공유하기 🔗'
           isOutlined={true}
           onClick={() => {
-            //TODO: 초대링크 복사
-            showToast('클립보드에 복사됨');
+            console.log(location.state.teamId);
+            if (location.state.teamId) {
+              inviteTeam(location.state.teamId, {
+                onSuccess: (data) => {
+                  const inviteCode = data.token;
+                  navigator.clipboard.writeText(`feedhanjum.com/${inviteCode}`);
+                  showToast('클립보드에 복사됨');
+                },
+              });
+            }
           }}
         />
         <div className='absolute -bottom-12 left-1/2 flex w-[200px] -translate-x-1/2 animate-pulse items-center justify-center rounded-full bg-gray-700 px-6 py-1 text-gray-200 before:absolute before:-top-4 before:left-1/2 before:-translate-x-1/2 before:border-[8px] before:border-transparent before:border-b-gray-700'>
@@ -34,7 +46,7 @@ export default function TeamSpaceMakeSuccess() {
         <LargeButton
           text={location.state?.from === '/first' ? '시작하기' : '흠으로'}
           isOutlined={false}
-          onClick={location.state?.from === '/first' ? () => {} : () => {}}
+          onClick={() => navigate('/main')}
         />
       </div>
     </div>


### PR DESCRIPTION
팀 스페이스 생성, 초대코드 API 적용 완료했습니다

팀 스페이스 초대코드 이용해서 만든 URL
<img width="624" alt="스크린샷 2025-02-11 오후 2 21 35" src="https://github.com/user-attachments/assets/be281b21-a9ec-48ff-9749-bcdc34ddcccd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated new capabilities to create teams and invite members, streamlining the team onboarding process.
  - Enhanced the team creation flow with improved navigation and updated button text, guiding users efficiently through the process.
  - Enabled the sharing of invite links with immediate feedback via clipboard copy and toast notifications.

- **Chores**
  - Disabled an outdated endpoint in the mock server to maintain a clean testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->