### PR TITLE
[FD-321] onSuccess 정상화

### DIFF
--- a/front-end/src/api/useAuth.js
+++ b/front-end/src/api/useAuth.js
@@ -11,12 +11,10 @@ export const useVerify = () => {
   });
 };
 
-export const useSignUp = (afterSuccess) => {
+export const useSignUp = () => {
   return useMutation({
     mutationFn: (data) => api.post({ url: '/api/auth/signup', body: data }),
-    onSuccess: () => {
-      afterSuccess();
-    },
+    onSuccess: () => {},
   });
 };
 

--- a/front-end/src/api/useFeedback.js
+++ b/front-end/src/api/useFeedback.js
@@ -78,7 +78,7 @@ export const useFeedbackFavorite = () => {
   });
 };
 
-export const useEditFavorite = (afterSuccess) => {
+export const useEditFavorite = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data) =>
@@ -86,7 +86,6 @@ export const useEditFavorite = (afterSuccess) => {
     onSuccess: () => {
       // TODO: 사용자 선호 피드백 정보 조회할때 캐시를 지우도록 수정
       // queryClient.invalidateQueries({ queryKey: ['feedback-favorite'] });
-      afterSuccess();
     },
   });
 };

--- a/front-end/src/api/useFeedback2.js
+++ b/front-end/src/api/useFeedback2.js
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from './baseApi';
 
-export const useFeedbackRequest = (afterSuccess) => {
+export const useFeedbackRequest = () => {
   // const queryClient = useQueryClient();
   return useMutation({
     /**
@@ -23,7 +23,6 @@ export const useFeedbackRequest = (afterSuccess) => {
       }),
     onSuccess: (data) => {
       // queryClient.invalidateQueries({ queryKey: ['feedback-sent'] }); // 추후 고민...
-      afterSuccess();
     },
     onError: (error) => {
       console.error('전송실패', error);
@@ -31,7 +30,7 @@ export const useFeedbackRequest = (afterSuccess) => {
   });
 };
 
-export const useFeedbackSelf = (afterSuccess) => {
+export const useFeedbackSelf = () => {
   // const queryClient = useQueryClient();
   return useMutation({
     /**
@@ -55,7 +54,6 @@ export const useFeedbackSelf = (afterSuccess) => {
       }),
     onSuccess: (data) => {
       // queryClient.invalidateQueries({ queryKey: ['feedback-sent'] }); // 추후 고민...
-      afterSuccess();
     },
     onError: (error) => {
       console.error('전송실패', error);

--- a/front-end/src/pages/feedback/FeedbackFavorite.jsx
+++ b/front-end/src/pages/feedback/FeedbackFavorite.jsx
@@ -17,13 +17,7 @@ export default function FeedbackFavorite() {
 
   const { data } = useFeedbackFavorite();
 
-  const mutation =
-    process === 'signup' ?
-      useSignUp(() => navigate('/main'))
-    : useEditFavorite(() => {
-        navigate('/mypage');
-        showToast('수정 완료');
-      });
+  const mutation = process === 'signup' ? useSignUp() : useEditFavorite();
 
   const onKeywordButtonClick = (isStyle, keyword) => {
     const keywords = isStyle ? selectedStyle : selectedContent;
@@ -36,20 +30,22 @@ export default function FeedbackFavorite() {
   const onFinish = () => {
     selectedStyle.length === 0 && selectedContent.length === 0 ?
       showToast('피드백 유형을 선택해주세요')
-    : process === 'signup' ?
-      mutation.mutate({
-        email: 'email',
-        password: 'password',
-        name: 'name',
-        profileImage: {
-          iconName: 'iconName',
-          color: 'color',
+    : mutation.mutate(
+        {
+          ...location.state,
+          feedbackPreference: [...selectedStyle, ...selectedContent],
         },
-        feedbackPreference: [...selectedStyle, ...selectedContent],
-      })
-    : mutation.mutate({
-        feedbackPreference: [...selectedStyle, ...selectedContent],
-      });
+        {
+          onSuccess: () => {
+            if (process === 'signup') {
+              navigate('/main');
+            } else {
+              navigate('/mypage');
+              showToast('수정 완료');
+            }
+          },
+        },
+      );
   };
 
   return (

--- a/front-end/src/pages/feedback/FeedbackRequest.jsx
+++ b/front-end/src/pages/feedback/FeedbackRequest.jsx
@@ -19,9 +19,7 @@ export default function FeedbackRequest() {
   const receiverId = queryParams.get('receiverId');
   const receiverName = queryParams.get('receiverName');
 
-  const mutation = useFeedbackRequest(() =>
-    navigate(`/feedback/complete/?type=${'REQUEST'}`, { replace: true }),
-  );
+  const mutation = useFeedbackRequest();
 
   return (
     <div className='flex size-full flex-col'>
@@ -54,11 +52,19 @@ export default function FeedbackRequest() {
               showToast('내용을 입력해주세요');
             else if (textLength > 400) showToast('400자 이하로 작성해주세요');
             else
-              mutation.mutate({
-                receiverId: receiverId,
-                teamId: 1, // 나중에 전역 상태에서 가져오기
-                requestedContent: textContent.trim(),
-              });
+              mutation.mutate(
+                {
+                  receiverId: receiverId,
+                  teamId: 1, // 나중에 전역 상태에서 가져오기
+                  requestedContent: textContent.trim(),
+                },
+                {
+                  onSuccess: () =>
+                    navigate(`/feedback/complete/?type=${'REQUEST'}`, {
+                      replace: true,
+                    }),
+                },
+              );
           }}
         />
       </FooterWrapper>

--- a/front-end/src/pages/feedback/FeedbackSelf.jsx
+++ b/front-end/src/pages/feedback/FeedbackSelf.jsx
@@ -16,11 +16,7 @@ export default function FeedbackSelf() {
 
   const navigate = useNavigate();
 
-  const mutation = useFeedbackSelf(() =>
-    navigate(`/feedback/complete/?type=${'RETROSPECT'}`, {
-      replace: true,
-    }),
-  );
+  const mutation = useFeedbackSelf();
 
   return (
     <div className='flex size-full flex-col'>
@@ -55,12 +51,20 @@ export default function FeedbackSelf() {
             if (textLength === 0) showToast('내용을 입력해주세요');
             else if (textLength > 400) showToast('400자 이하로 작성해주세요');
             else
-              mutation.mutate({
-                writerId: 1, // 나중에 전역 상태에서 가져오기
-                teamId: 1, // 나중에 전역 상태에서 가져오기
-                title: titleContent,
-                content: textContent,
-              });
+              mutation.mutate(
+                {
+                  writerId: 1, // 나중에 전역 상태에서 가져오기
+                  teamId: 1, // 나중에 전역 상태에서 가져오기
+                  title: titleContent,
+                  content: textContent,
+                },
+                {
+                  onSuccess: () =>
+                    navigate(`/feedback/complete/?type=${'RETROSPECT'}`, {
+                      replace: true,
+                    }),
+                },
+              );
           }}
         />
       </FooterWrapper>


### PR DESCRIPTION
라우팅 관련한 onSuccess  동작들을 mutate함수에서 호출하도록 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the sign-up and feedback processes by removing redundant callback parameters.
	- Success actions, including navigation and notifications, are now handled within dedicated success handlers.
	- Updated mutation payload handling to dynamically use state data, ensuring a consistent and smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->