### PR TITLE
[FD-296]  팀 가입 시 일정에 해당 회원 추가 로직 구현

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/AddScheduleMemberEventHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/AddScheduleMemberEventHandler.java
@@ -1,0 +1,21 @@
+package com.feedhanjum.back_end.schedule.event.handler;
+
+import com.feedhanjum.back_end.schedule.service.ScheduleService;
+import com.feedhanjum.back_end.team.event.TeamMemberJoinEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AddScheduleMemberEventHandler {
+
+    private final ScheduleService scheduleService;
+
+    @Async
+    @EventListener
+    public void addNewScheduleMember(TeamMemberJoinEvent event) {
+        scheduleService.addNewScheduleMembership(event.memberId(), event.teamId());
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleRepository.java
@@ -17,4 +17,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findByEndTimeBetween(LocalDateTime endTimeAfter, LocalDateTime endTimeBefore);
 
+    List<Schedule> findAllByTeam_IdAndEndTimeGreaterThanEqual(Long teamId, LocalDateTime now);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamMemberJoinEvent.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/event/TeamMemberJoinEvent.java
@@ -1,0 +1,4 @@
+package com.feedhanjum.back_end.team.event;
+
+public record TeamMemberJoinEvent(Long memberId, Long teamId) {
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -6,6 +6,7 @@ import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleQueryRepository;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamJoinToken;
+import com.feedhanjum.back_end.team.event.TeamMemberJoinEvent;
 import com.feedhanjum.back_end.team.event.TeamMemberLeftEvent;
 import com.feedhanjum.back_end.team.exception.TeamLeaderMustExistException;
 import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
@@ -165,6 +166,7 @@ public class TeamService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
         teamJoinToken.joinTeam(member);
+        eventPublisher.publishEvent(new TeamMemberJoinEvent(memberId, teamJoinToken.getTeamInfo().getId()));
     }
 
 


### PR DESCRIPTION
# 관련 이슈
FD-296

# 변경된 점
- [x] 팀 가입 시, 아직 끝나지 않은 일정에 해당 회원을 추가로 등록하여, 역할 입력이 가능하도록 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Team details now display key scheduling information, including the earliest start and latest end times.
  - Enhanced team update validations ensure that team dates align with active scheduled events.
  - New automation associates new team members with ongoing schedules seamlessly.

- **Tests**
  - Expanded test coverage verifies the new date validations and scheduling constraints for team updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->