### PR TITLE
[FD-322, FD-323]  피드백 선호도 선택지 조회 api 구현

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
@@ -35,7 +35,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .addPathPatterns("/api/**")
                 .excludePathPatterns("/api/team/find")
                 .excludePathPatterns("/api/auth/**")
-                .excludePathPatterns("/api/feedback/preference");
+                .excludePathPatterns("/api/feedback/preference")
+                .excludePathPatterns("/api/feedback/objective");
     }
 
     @Override

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
@@ -34,7 +34,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(authInterceptor())
                 .addPathPatterns("/api/**")
                 .excludePathPatterns("/api/team/find")
-                .excludePathPatterns("/api/auth/**");
+                .excludePathPatterns("/api/auth/**")
+                .excludePathPatterns("/api/feedback/preference");
     }
 
     @Override

--- a/back-end/src/main/java/com/feedhanjum/back_end/core/exception/ValidationControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/exception/ValidationControllerAdvice.java
@@ -4,6 +4,7 @@ import jakarta.validation.ConstraintViolationException;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -48,4 +49,10 @@ public class ValidationControllerAdvice {
     public ResponseEntity<String> handleSecurityException(SecurityException e){
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
     }
+    
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Malformed JSON request: " + e.getMessage());
+    }
+    
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackController.java
@@ -11,6 +11,7 @@ import com.feedhanjum.back_end.feedback.service.FeedbackQueryService;
 import com.feedhanjum.back_end.feedback.service.FeedbackService;
 import com.feedhanjum.back_end.feedback.service.dto.ReceivedFeedbackDto;
 import com.feedhanjum.back_end.feedback.service.dto.SentFeedbackDto;
+import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,8 +24,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -156,7 +156,7 @@ public class FeedbackController {
     @Operation(summary = "받은 피드백 조회하기", description = "받은 피드백을 조회힙니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "보낸 피드백 조회 성공", useReturnTypeSchema = true),
-            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우",content = @Content)
+            @ApiResponse(responseCode = "403", description = "본인이 아닌 경우", content = @Content)
     })
     @GetMapping("/feedbacks/receiver/{receiverId}")
     public ResponseEntity<Paged<ReceivedFeedbackDto>> getReceivedFeedbacks(@Login Long loginId,
@@ -169,4 +169,15 @@ public class FeedbackController {
         return ResponseEntity.ok(Paged.from(receivedFeedbacks));
     }
 
+    @Operation(summary = "피드백 선호도 선택지 조회", description = "사용자에게 피드백 선호도 선택지를 제공하기 위한 API")
+    @ApiResponse(responseCode = "200", description = "선택 가능한 피드백 선호 정보를 반환한다.")
+    @GetMapping("/feedback/preference")
+    public ResponseEntity<Map<String,List<String>>> getSelectableFeedbackPreference() {
+        Map<String, List<String>> feedbackPreferenceMap = new HashMap<>();
+        for (FeedbackPreference feedbackPreference : FeedbackPreference.values()) {
+            List<String> descriptions = feedbackPreferenceMap.computeIfAbsent(feedbackPreference.getType(), key -> new ArrayList<>());
+            descriptions.add(feedbackPreference.getDescription());
+        }
+        return ResponseEntity.ok(feedbackPreferenceMap);
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackController.java
@@ -8,6 +8,7 @@ import com.feedhanjum.back_end.feedback.controller.dto.response.FrequentFeedback
 import com.feedhanjum.back_end.feedback.controller.dto.response.RegularFeedbackRequestForApiResponse;
 import com.feedhanjum.back_end.feedback.domain.FeedbackReport;
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.feedback.domain.ObjectiveFeedback;
 import com.feedhanjum.back_end.feedback.exception.NoRegularFeedbackRequestException;
 import com.feedhanjum.back_end.feedback.service.FeedbackQueryService;
 import com.feedhanjum.back_end.feedback.service.FeedbackService;
@@ -170,17 +171,30 @@ public class FeedbackController {
         Page<ReceivedFeedbackDto> receivedFeedbacks = feedbackQueryService.getReceivedFeedbacks(receiverId, request.teamId(), request.filterHelpful(), request.page(), request.sortOrder());
         return ResponseEntity.ok(Paged.from(receivedFeedbacks));
     }
-  
+
     @Operation(summary = "피드백 선호도 선택지 조회", description = "사용자에게 피드백 선호도 선택지를 제공하기 위한 API")
     @ApiResponse(responseCode = "200", description = "선택 가능한 피드백 선호 정보를 반환한다.")
     @GetMapping("/feedback/preference")
-    public ResponseEntity<Map<String,List<String>>> getSelectableFeedbackPreference() {
+    public ResponseEntity<Map<String, List<String>>> getSelectableFeedbackPreference() {
         Map<String, List<String>> feedbackPreferenceMap = new HashMap<>();
         for (FeedbackPreference feedbackPreference : FeedbackPreference.values()) {
             List<String> descriptions = feedbackPreferenceMap.computeIfAbsent(feedbackPreference.getType(), key -> new ArrayList<>());
             descriptions.add(feedbackPreference.getDescription());
         }
         return ResponseEntity.ok(feedbackPreferenceMap);
+    }
+
+    @Operation(summary = "객관식 피드백 선택지 조회", description = "사용자에게 객관식 피드백 선택지를 제공하기 위한 API")
+    @ApiResponse(responseCode = "200", description = "선택 가능한 객관식 피드백 정보를 반환한다.")
+    @GetMapping("/feedback/objective")
+    public ResponseEntity<Map<String, Map<String, List<String>>>> getSelectableObjectFeedbacks() {
+        Map<String, Map<String, List<String>>> objectiveFeedbacksMap = new HashMap<>();
+        for (ObjectiveFeedback objectiveFeedback : ObjectiveFeedback.values()) {
+            Map<String, List<String>> objectiveFeedbackFeelingMap = objectiveFeedbacksMap.computeIfAbsent(objectiveFeedback.getFeeling().getDescription(), key -> new HashMap<>());
+            List<String> objectiveFeedbackDescriptions = objectiveFeedbackFeelingMap.computeIfAbsent(objectiveFeedback.getCategory().getDescription(), key -> new ArrayList<>());
+            objectiveFeedbackDescriptions.add(objectiveFeedback.getDescription());
+        }
+        return ResponseEntity.ok(objectiveFeedbacksMap);
     }
 
     @Operation(summary = "피드백 리포트 조회", description = "로그인 유저의 피드백 리포트를 조회힙니다.")
@@ -192,5 +206,4 @@ public class FeedbackController {
         FeedbackReport feedbackReport = feedbackQueryService.getFeedbackReport(receiverId);
         return ResponseEntity.ok(FeedbackReportDto.from(feedbackReport));
     }
-
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackRefinementController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/FeedbackRefinementController.java
@@ -23,7 +23,7 @@ public class FeedbackRefinementController {
     })
     @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<FeedbackRefineResponse> refineFeedback(@Valid @RequestBody FeedbackRefineRequest request) {
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new FeedbackRefineResponse("테스트 데이터입니다", 3));
     }
 
     @Operation(summary = "남은 호출 가능 횟수 조회", description = "주관식 피드백 다듬기 호출 가능 횟수를 조회합니다.")

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/domain/FeedbackPreference.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/domain/FeedbackPreference.java
@@ -3,6 +3,7 @@ package com.feedhanjum.back_end.member.domain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 
 import java.util.HashMap;
 import java.util.List;
@@ -13,22 +14,22 @@ import java.util.Set;
         allowableValues = {"완곡한", "솔직한", "가벼운", "신중한", "간단한", "구체적인", "칭찬과 함께", "유머러스한", "현실적인", "이상적인", "논리적인", "핵심적인", "발전적인", "대안을 제시하는", "명확한", "색다른"}
 )
 public enum FeedbackPreference {
-    EUPHEMISTIC("완곡한"),
-    HONEST("솔직한"),
-    LIGHT("가벼운"),
-    CAUTIOUS("신중한"),
-    SIMPLE("간단한"),
-    DETAILED("구체적인"),
-    COMPLEMENTING("칭찬과 함께"),
-    HUMOROUS("유머러스한"),
-    REALISTIC("현실적인"),
-    IDEALISTIC("이상적인"),
-    LOGICAL("논리적인"),
-    ESSENTIAL("핵심적인"),
-    PROGRESSIVE("발전적인"),
-    ALTERNATIVE_SUGGESTING("대안을 제시하는"),
-    CLEAR("명확한"),
-    UNCONVENTIONAL("색다른");
+    EUPHEMISTIC("완곡한", Constants.STYLE_PREFERENCE),
+    HONEST("솔직한", Constants.STYLE_PREFERENCE),
+    LIGHT("가벼운", Constants.STYLE_PREFERENCE),
+    CAUTIOUS("신중한", Constants.STYLE_PREFERENCE),
+    SIMPLE("간단한", Constants.STYLE_PREFERENCE),
+    DETAILED("구체적인", Constants.STYLE_PREFERENCE),
+    COMPLEMENTING("칭찬과 함께", Constants.STYLE_PREFERENCE),
+    HUMOROUS("유머러스한", Constants.STYLE_PREFERENCE),
+    REALISTIC("현실적인", Constants.CONTENT_PREFERENCE),
+    IDEALISTIC("이상적인", Constants.CONTENT_PREFERENCE),
+    LOGICAL("논리적인", Constants.CONTENT_PREFERENCE),
+    ESSENTIAL("핵심적인", Constants.CONTENT_PREFERENCE),
+    PROGRESSIVE("발전적인", Constants.CONTENT_PREFERENCE),
+    ALTERNATIVE_SUGGESTING("대안을 제시하는", Constants.CONTENT_PREFERENCE),
+    CLEAR("명확한", Constants.CONTENT_PREFERENCE),
+    UNCONVENTIONAL("색다른", Constants.CONTENT_PREFERENCE);
 
     private static final Map<String, FeedbackPreference> FEEDBACK_PREFERENCE_MAP = new HashMap<>();
     private static final Set<FeedbackPreference> STYLE_PREFERENCES = Set.of(
@@ -45,9 +46,12 @@ public enum FeedbackPreference {
     }
 
     private final String description;
+    @Getter
+    private final String type;
 
-    FeedbackPreference(String description) {
+    FeedbackPreference(String description, String type) {
         this.description = description;
+        this.type = type;
     }
 
     public static int countStylePreference(List<FeedbackPreference> preferences) {
@@ -84,5 +88,10 @@ public enum FeedbackPreference {
             throw new IllegalArgumentException("Invalid description: " + content);
         }
         return feedbackPreference;
+    }
+
+    private static class Constants {
+        public static final String STYLE_PREFERENCE = "스타일";
+        public static final String CONTENT_PREFERENCE = "내용";
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/AddScheduleMemberEventHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/AddScheduleMemberEventHandler.java
@@ -3,12 +3,14 @@ package com.feedhanjum.back_end.schedule.event.handler;
 import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.team.event.TeamMemberJoinEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class AddScheduleMemberEventHandler {
 
     private final ScheduleService scheduleService;

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/AddScheduleMemberEventHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/AddScheduleMemberEventHandler.java
@@ -16,6 +16,12 @@ public class AddScheduleMemberEventHandler {
     @Async
     @EventListener
     public void addNewScheduleMember(TeamMemberJoinEvent event) {
-        scheduleService.addNewScheduleMembership(event.memberId(), event.teamId());
+        try {
+            scheduleService.addNewScheduleMembership(event.memberId(), event.teamId());
+        } catch (Exception e) {
+            // Log the error and potentially trigger a compensating action
+            log.error("Failed to add schedule membership for member {} in team {}: {}",
+                      event.memberId(), event.teamId(), e.getMessage(), e);
+        }
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/RemoveScheduleMemberEventHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/RemoveScheduleMemberEventHandler.java
@@ -3,12 +3,14 @@ package com.feedhanjum.back_end.schedule.event.handler;
 import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.team.event.TeamMemberLeftEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class RemoveScheduleMemberEventHandler {
 
     private final ScheduleService scheduleService;

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/RemoveScheduleMemberEventHandler.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/event/handler/RemoveScheduleMemberEventHandler.java
@@ -16,6 +16,12 @@ public class RemoveScheduleMemberEventHandler {
     @Async
     @EventListener
     public void removeRemainScheduleMember(TeamMemberLeftEvent event) {
-        scheduleService.removeRemainScheduleMembership(event.memberId(), event.teamId());
+        try {
+            scheduleService.removeRemainScheduleMembership(event.memberId(), event.teamId());
+        } catch (Exception e) {
+            // Log the error and potentially trigger a compensating action
+            log.error("Failed to remove schedule membership for member {} in team {}: {}",
+                event.memberId(), event.teamId(), e.getMessage(), e);
+        }
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleMemberRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleMemberRepository.java
@@ -4,6 +4,7 @@ import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -12,7 +13,8 @@ public interface ScheduleMemberRepository extends JpaRepository<ScheduleMember, 
 
     Optional<ScheduleMember> findByMemberIdAndScheduleId(Long memberId, Long scheduleId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
+    @Transactional
     @Query("delete from ScheduleMember sm where sm.member.id = :memberId and sm.schedule.team.id = :teamId and sm.schedule.endTime > :now")
     void deleteScheduleMembersByMemberIdAndTeamIdAfterNow(Long memberId, Long teamId, LocalDateTime now);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleMemberRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleMemberRepository.java
@@ -2,10 +2,17 @@ package com.feedhanjum.back_end.schedule.repository;
 
 import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface ScheduleMemberRepository extends JpaRepository<ScheduleMember, Long> {
 
     Optional<ScheduleMember> findByMemberIdAndScheduleId(Long memberId, Long scheduleId);
+
+    @Modifying
+    @Query("delete from ScheduleMember sm where sm.member.id = :memberId and sm.schedule.team.id = :teamId and sm.schedule.endTime > :now")
+    void deleteScheduleMembersByMemberIdAndTeamIdAfterNow(Long memberId, Long teamId, LocalDateTime now);
 }


### PR DESCRIPTION
# 관련 이슈
FD-323

# 변경된 점
- [x] 피드백 선호도 선택지를 조회할 수 있는 API 구현
- [x] 회원가입 로직을 고려하여, 피드백 선호도 선택지 조회 api를 로그인 필터에서 제외
- [x] 선택 가능한 객관식 피드백을 조회할 수 있는 API 구현 및 로그인 없이 확인 가능하도록 설정
- [x] HttpMessageNotReadableException 에 대한 Controller Advice 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new endpoints to retrieve selectable feedback preferences and objectives.
  - Enhanced error messaging to more clearly indicate malformed request payloads.

- **Enhancements**
  - Refined feedback responses to return meaningful data.
  - Optimized authentication behavior to ensure smooth access to feedback-related endpoints.
  - Improved team scheduling and membership management with automated updates on join/leave events and stricter date validations.
  - Updated feedback categorization to clearly differentiate between style and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->