### PR TITLE
[FD-208] 일정추가 삭제 api 적용

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -23,7 +23,6 @@ import FeedbackComplete from './pages/feedback/FeedbackComplete';
 import FeedbackSelf from './pages/feedback/FeedbackSelf';
 import SelfFeedback from './pages/mypage/SelfFeedback';
 import CombinedProvider from './CombinedProvider';
-import { TeamProvider } from './TeamContext';
 import FeedbackFavorite from './pages/feedback/FeedbackFavorite';
 
 const queryClient = new QueryClient();

--- a/front-end/src/api/baseApi.js
+++ b/front-end/src/api/baseApi.js
@@ -40,7 +40,12 @@ const request = async (method, url, params = {}, body) => {
     if (!response.ok) {
       throw new Error(`HTTP error! Status: ${response.status}`);
     }
-    return response.json();
+    const text = await response.text();
+    if (!text) {
+      return {};
+    } else {
+      return JSON.parse(text);
+    }
   } catch (error) {
     console.error('API Request Error:', error);
     throw error;

--- a/front-end/src/api/useCalendar.js
+++ b/front-end/src/api/useCalendar.js
@@ -1,3 +1,4 @@
+import { showToast } from '../utility/handleToast';
 import { api } from './baseApi';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -18,8 +19,11 @@ export const useGetSchedules = (params) => {
         startDay: params.startDay,
         endDay: params.endDay,
       };
-      const response = api.get({ url: '/api/schedules', params: sendingData });
-      return response;
+      if (params.teamId) {
+        return api.get({ url: '/api/schedules', params: sendingData });
+      } else {
+        return null;
+      }
     },
   });
 };
@@ -44,7 +48,9 @@ export const usePostSchedule = (teamId) => {
   return useMutation({
     mutationFn: (data) =>
       api.post({ url: `/api/team/${teamId}/schedule/create`, body: data }),
-    onSuccess: () => {
+    onSuccess: (data) => {
+      console.log(data);
+      console.log('성공 테스트1');
       queryClient.invalidateQueries({ queryKey: ['schedules'] });
     },
   });

--- a/front-end/src/api/useCalendar.js
+++ b/front-end/src/api/useCalendar.js
@@ -53,11 +53,12 @@ export const usePostSchedule = (teamId) => {
 export const useEditSchedule = (teamId) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (scheduleId, data) =>
-      api.post({
+    mutationFn: ({ scheduleId, data }) => {
+      return api.post({
         url: `/api/team/${teamId}/schedule/${scheduleId}`,
         body: data,
-      }),
+      });
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['schedules'] });
     },

--- a/front-end/src/api/useCalendar.js
+++ b/front-end/src/api/useCalendar.js
@@ -50,13 +50,26 @@ export const usePostSchedule = (teamId) => {
   });
 };
 
-export const usePutSchedule = (teamId, scheduleId) => {
+export const useEditSchedule = (teamId) => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data) =>
-      api.put({
+    mutationFn: (scheduleId, data) =>
+      api.post({
         url: `/api/team/${teamId}/schedule/${scheduleId}`,
         body: data,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['schedules'] });
+    },
+  });
+};
+
+export const useDeleteSchedule = (teamId) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (scheduleId) =>
+      api.delete({
+        url: `/api/team/${teamId}/schedule/${scheduleId}`,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['schedules'] });

--- a/front-end/src/api/useMainPage.js
+++ b/front-end/src/api/useMainPage.js
@@ -7,7 +7,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 export const useMyTeams = () => {
   return useQuery({
     queryKey: ['myTeams'],
-    queryFn: () => api.get({ url: '/api/team/my-teams2' }),
+    queryFn: () => api.get({ url: '/api/team/my-teams' }),
   });
 };
 

--- a/front-end/src/mocks/handlers.js
+++ b/front-end/src/mocks/handlers.js
@@ -5,9 +5,9 @@ const BASE_URL = 'https://api.feedhanjum.com';
 
 export const handlers = [
   // 팀 목록 조회
-  http.get(`${BASE_URL}/api/team/my-teams`, () => {
-    return HttpResponse.json(teams);
-  }),
+  // http.get(`${BASE_URL}/api/team/my-teams`, () => {
+  //   return HttpResponse.json(teams);
+  // }),
 
   // 메인 카드 조회
   http.get(`${BASE_URL}/api/team/:teamId/schedule`, () => {

--- a/front-end/src/mocks/handlers2.js
+++ b/front-end/src/mocks/handlers2.js
@@ -34,9 +34,9 @@ export const handlers2 = [
   }),
 
   // 팀 목록 조회
-  http.get(`${BASE_URL}/api/team/my-teams2`, () => {
-    return HttpResponse.json(teams2);
-  }),
+  // http.get(`${BASE_URL}/api/team/my-teams2`, () => {
+  //   return HttpResponse.json(teams2);
+  // }),
 
   // 일정 조회
   http.get(`${BASE_URL}/api/schedules`, () => {
@@ -59,9 +59,9 @@ export const handlers2 = [
   // }),
 
   // 팀 조회
-  http.get(`${BASE_URL}/api/team/:teamId`, () => {
-    return HttpResponse.json(teamResponse);
-  }),
+  // http.get(`${BASE_URL}/api/team/:teamId`, () => {
+  //   return HttpResponse.json(teamResponse);
+  // }),
 
   // 팀 멤버 조회
   http.get(`${BASE_URL}/api/team/:teamId/members`, () => {

--- a/front-end/src/mocks/handlers2.js
+++ b/front-end/src/mocks/handlers2.js
@@ -8,9 +8,6 @@ import { http, HttpResponse } from 'msw';
 import {
   verifySignupResponse,
   signupResponse,
-  loginResponse,
-  teams2,
-  createScheduleResponse,
   updateScheduleResponse,
   schedules2,
   members2,
@@ -33,16 +30,6 @@ export const handlers2 = [
     return HttpResponse.json(signupResponse);
   }),
 
-  // 팀 목록 조회
-  // http.get(`${BASE_URL}/api/team/my-teams2`, () => {
-  //   return HttpResponse.json(teams2);
-  // }),
-
-  // 일정 조회
-  http.get(`${BASE_URL}/api/schedules`, () => {
-    return HttpResponse.json(schedules2);
-  }),
-
   // 팀 일정 조회
   http.get(`${BASE_URL}/api/team/:teamId/schedules`, () => {
     return HttpResponse.json(schedules2);
@@ -52,16 +39,6 @@ export const handlers2 = [
   http.put(`${BASE_URL}/api/team/:teamId/schedule/:scheduleId`, () => {
     return HttpResponse.json(updateScheduleResponse);
   }),
-
-  // 일정 삭제
-  // http.delete(`${BASE_URL}/api/team/:teamId/schedule/:scheduleId`, () => {
-  //   return HttpResponse.json(deleteScheduleResponse);
-  // }),
-
-  // 팀 조회
-  // http.get(`${BASE_URL}/api/team/:teamId`, () => {
-  //   return HttpResponse.json(teamResponse);
-  // }),
 
   // 팀 멤버 조회
   http.get(`${BASE_URL}/api/team/:teamId/members`, () => {

--- a/front-end/src/mocks/mockData2.js
+++ b/front-end/src/mocks/mockData2.js
@@ -275,10 +275,12 @@ export const members2 = [
   },
 ];
 
-export const teamResponse = {
-  teamResponse: teams2[0],
-  members: members2,
-};
+export const teamResponse = [
+  {
+    teamResponse: teams2[0],
+    members: members2,
+  },
+];
 
 export const feedbackReceivedResponse = {
   page: 1073741824,

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -26,15 +26,15 @@ export default function Calendar() {
   );
 
   // 일정 조회, 저장 관련
-  const { setAllSchedules, scheduleOnDate, scheduleSet } = useSchedule(
-    selectedTeam,
-    selectedDate,
-  );
-  const [selectedSchedule, setSelectedSchedule] = useState(
-    scheduleOnDate ? scheduleOnDate[0] : null,
-  );
+  const {
+    setAllSchedules,
+    scheduleOnDate,
+    scheduleSet,
+    selectedSchedule,
+    setSelectedSchedule,
+  } = useSchedule(selectedTeam, selectedDate);
 
-  // 일정 수정, 삭제 관련
+  // 일정 등록, 수정, 삭제 등 액션 관련
   const { doingAction, setDoingAction, actionType, setActionType } =
     useScheduleAction(selectedDate, selectedSchedule);
 
@@ -114,12 +114,6 @@ export default function Calendar() {
           selectedDateFromParent={selectedDate}
           selectedScheduleFromParent={selectedSchedule}
           onClose={() => setDoingAction(false)}
-          onSubmit={(postSuccess) => {
-            setDoingAction(false);
-            if (postSuccess) {
-              // TODO: 일정 재조회
-            }
-          }}
         />
       )}
     </div>

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -25,7 +25,7 @@ export default function Calendar() {
     location.state?.initialDate ?? new Date(new Date().setHours(0, 0, 0, 0)),
   );
 
-  // 일정 조회, 저장 관련
+  // 일정 조회 관련
   const {
     setAllSchedules,
     scheduleOnDate,
@@ -35,8 +35,14 @@ export default function Calendar() {
   } = useSchedule(selectedTeam, selectedDate);
 
   // 일정 등록, 수정, 삭제 등 액션 관련
-  const { doingAction, setDoingAction, actionType, setActionType } =
-    useScheduleAction(selectedDate, selectedSchedule);
+  const {
+    doingAction,
+    setDoingAction,
+    actionType,
+    setActionType,
+    clearData,
+    refresh,
+  } = useScheduleAction(selectedDate, selectedSchedule);
 
   // 일정 화면 스크롤 관련
   const { scrollRef, isScrolling } = useCalendarScroll();
@@ -99,6 +105,7 @@ export default function Calendar() {
               </p>
             }
             onClick={() => {
+              clearData();
               setActionType(ScheduleActionType.ADD);
               setDoingAction(true);
             }}
@@ -109,6 +116,7 @@ export default function Calendar() {
       </ul>
       {scheduleOnDate && (
         <ScheduleAction
+          key={refresh}
           type={actionType}
           isOpen={doingAction}
           selectedDateFromParent={selectedDate}

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -30,9 +30,13 @@ export default function Calendar() {
     selectedTeam,
     selectedDate,
   );
+  const [selectedSchedule, setSelectedSchedule] = useState(
+    scheduleOnDate ? scheduleOnDate[0] : null,
+  );
+
   // 일정 수정, 삭제 관련
   const { doingAction, setDoingAction, actionType, setActionType } =
-    useScheduleAction();
+    useScheduleAction(selectedDate, selectedSchedule);
 
   // 일정 화면 스크롤 관련
   const { scrollRef, isScrolling } = useCalendarScroll();
@@ -77,8 +81,9 @@ export default function Calendar() {
                   todos={schedule.scheduleMemberNestedDtoList}
                   isFinished={checkIsFinished(schedule.endTime)}
                   onClickEdit={() => {
+                    console.log(schedule);
+                    setSelectedSchedule(schedule);
                     setActionType(ScheduleActionType.EDIT);
-                    setDoingAction(true);
                     setDoingAction(true);
                   }}
                 />
@@ -96,7 +101,6 @@ export default function Calendar() {
             onClick={() => {
               setActionType(ScheduleActionType.ADD);
               setDoingAction(true);
-              setDoingAction(true);
             }}
             isOutlined={true}
             disabled={true}
@@ -108,9 +112,7 @@ export default function Calendar() {
           type={actionType}
           isOpen={doingAction}
           selectedDateFromParent={selectedDate}
-          selectedSchedule={scheduleOnDate.find(
-            (schedule) => schedule.teamId === selectedTeam,
-          )}
+          selectedScheduleFromParent={selectedSchedule}
           onClose={() => setDoingAction(false)}
           onSubmit={(postSuccess) => {
             setDoingAction(false);

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -41,7 +41,7 @@ export default function Calendar() {
     actionType,
     setActionType,
     clearData,
-    refresh,
+    actionInfo,
   } = useScheduleAction(selectedDate, selectedSchedule);
 
   // 일정 화면 스크롤 관련
@@ -116,12 +116,12 @@ export default function Calendar() {
       </ul>
       {scheduleOnDate && (
         <ScheduleAction
-          key={refresh}
           type={actionType}
           isOpen={doingAction}
           selectedDateFromParent={selectedDate}
           selectedScheduleFromParent={selectedSchedule}
           onClose={() => setDoingAction(false)}
+          actionInfo={actionInfo}
         />
       )}
     </div>

--- a/front-end/src/pages/calendar/components/CalendarParts.jsx
+++ b/front-end/src/pages/calendar/components/CalendarParts.jsx
@@ -122,7 +122,6 @@ export function CalendarWeek({
                 haveSchedule={scheduleSet.has(
                   new Date(toKST(date)).toISOString().split('T')[0],
                 )}
-                setSelectedDate={setSelectedDate}
               />
             </div>
           );

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -55,18 +55,12 @@ export default function ScheduleAction({
     setEndTime,
     todos,
     setTodo,
+    clearData,
   } = useScheduleAction(selectedDateFromParent, selectedScheduleFromParent);
 
   const { mutate: postSchedule } = usePostSchedule(selectedTeam);
   const { mutate: editSchedule } = useEditSchedule(selectedTeam);
   const { mutate: deleteSchedule } = useDeleteSchedule(selectedTeam);
-
-  function clearData() {
-    setScheduleName('');
-    setStartTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
-    setEndTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
-    setTodo([]);
-  }
 
   return (
     <div
@@ -182,6 +176,7 @@ export default function ScheduleAction({
               type === ScheduleActionType.ADD ?
                 postSchedule(sendingData, {
                   onSuccess: () => {
+                    onClose();
                     showToast('일정이 추가되었어요');
                     clearData();
                   },
@@ -193,6 +188,7 @@ export default function ScheduleAction({
                   },
                   {
                     onSuccess: () => {
+                      onClose();
                       showToast('일정이 수정되었어요');
                       clearData();
                     },

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -39,7 +39,6 @@ export default function ScheduleAction({
   type,
   isOpen,
   onClose,
-  onSubmit,
   selectedScheduleFromParent,
   selectedDateFromParent,
 }) {
@@ -176,8 +175,8 @@ export default function ScheduleAction({
             if (checkNewSchedule(scheduleName, startTime, endTime)) {
               const sendingData = {
                 name: scheduleName,
-                startTime: startTime.toTimeString(),
-                endTime: endTime.toTimeString(),
+                startTime: toKST(startTime).toISOString(),
+                endTime: toKST(endTime).toISOString(),
                 todos: todos,
               };
               type === ScheduleActionType.ADD ?
@@ -185,17 +184,17 @@ export default function ScheduleAction({
                   onSuccess: () => {
                     showToast('일정이 추가되었어요');
                     clearData();
-                    onSubmit(true); // 추가 성공여부 파라미터로 받음
                   },
                 })
               : editSchedule(
-                  selectedScheduleFromParent.scheduleId ?? -1,
-                  sendingData,
+                  {
+                    scheduleId: selectedScheduleFromParent.scheduleId ?? -1,
+                    data: sendingData,
+                  },
                   {
                     onSuccess: () => {
                       showToast('일정이 수정되었어요');
                       clearData();
-                      onSubmit(true); // 수정 성공여부 파라미터로 받음
                     },
                   },
                 );

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import Icon from '../../../components/Icon';
 import { useEffect, useRef, useState } from 'react';
-import { changeDayName, timePickerToDate } from '../../../utility/time';
+import { changeDayName, timePickerToDate, toKST } from '../../../utility/time';
 import CustomInput from '../../../components/CustomInput';
 import LargeButton from '../../../components/buttons/LargeButton';
 import StickyWrapper from '../../../components/wrappers/StickyWrapper';
@@ -14,9 +14,13 @@ import ScheduleDeleteModal from './ScheduleDeleteModal';
 import CustomDatePicker, {
   DatePickerButton,
 } from '../../../components/CustomDatePicker';
-import { useUser } from '../../../useUser';
-import { usePostSchedule } from '../../../api/useCalendar';
+import {
+  useDeleteSchedule,
+  useEditSchedule,
+  usePostSchedule,
+} from '../../../api/useCalendar';
 import { useTeam } from '../../../useTeam';
+import useScheduleAction from '../hooks/useScheduleAction';
 
 export const ScheduleActionType = Object.freeze({
   ADD: 'add',
@@ -36,52 +40,32 @@ export default function ScheduleAction({
   isOpen,
   onClose,
   onSubmit,
+  selectedScheduleFromParent,
   selectedDateFromParent,
-  selectedSchedule,
 }) {
-  const { userId } = useUser();
   const { selectedTeam } = useTeam();
-  // 달력 선택 날짜를 기존 날짜로 초기화
-  const [selectedDate, setSelectedDate] = useState(selectedDateFromParent);
-  const [scheduleName, setScheduleName] = useState(
-    selectedSchedule?.scheduleName ?? '',
-  );
-  const [startTime, setStartTime] = useState(
-    selectedSchedule?.scheduleInfo?.startTime.split('T')[1].slice(0, 5) ??
-      '12:00',
-  );
-  const [endTime, setEndTime] = useState(
-    selectedSchedule?.scheduleInfo?.endTime.split('T')[1].slice(0, 5) ??
-      '12:00',
-  );
-  const [todos, setTodo] = useState(
-    selectedSchedule?.todos?.filter((todo) => {
-      return todo.memberId === userId;
-    }).task ?? [],
-  );
   const scrollRef = useRef(null);
+  const {
+    selectedDate,
+    setSelectedDate,
+    scheduleName,
+    setScheduleName,
+    startTime,
+    setStartTime,
+    endTime,
+    setEndTime,
+    todos,
+    setTodo,
+  } = useScheduleAction(selectedDateFromParent, selectedScheduleFromParent);
 
-  const { mutate: postSchedule, isSuccess } = usePostSchedule(selectedTeam);
-
-  useEffect(() => {
-    setSelectedDate(selectedDateFromParent);
-
-    setScheduleName(selectedSchedule?.scheduleName ?? '');
-    setStartTime(
-      selectedSchedule?.startTime.split('T')[1].slice(0, 5) ?? '12:00',
-    );
-    setEndTime(selectedSchedule?.endTime.split('T')[1].slice(0, 5) ?? '12:00');
-    const newTodos =
-      selectedSchedule?.todos?.find((todo) => {
-        return todo.memberId === 1;
-      })?.task ?? [];
-    setTodo(newTodos);
-  }, [selectedDateFromParent, selectedSchedule]);
+  const { mutate: postSchedule } = usePostSchedule(selectedTeam);
+  const { mutate: editSchedule } = useEditSchedule(selectedTeam);
+  const { mutate: deleteSchedule } = useDeleteSchedule(selectedTeam);
 
   function clearData() {
     setScheduleName('');
-    setStartTime('12:00');
-    setEndTime('12:00');
+    setStartTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
+    setEndTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
     setTodo([]);
   }
 
@@ -99,14 +83,34 @@ export default function ScheduleAction({
         </h1>
         {type === ScheduleActionType.EDIT && (
           <button
-            onClick={() => showModal(<ScheduleDeleteModal onClose={onClose} />)}
+            onClick={() =>
+              showModal(
+                <ScheduleDeleteModal
+                  deleteSchedule={() => {
+                    deleteSchedule(
+                      selectedScheduleFromParent.scheduleId ?? -1,
+                      {
+                        onSuccess: () => {
+                          showToast('일정을 삭제했습니다');
+                          hideModal();
+                          onClose();
+                        },
+                      },
+                    );
+                  }}
+                  onClose={onClose}
+                />,
+              )
+            }
           >
             <Icon name='remove' className='absolute top-5 left-0 text-white' />
           </button>
         )}
         <button
           onClick={() => {
-            clearData();
+            if (type !== ScheduleActionType.EDIT) {
+              clearData();
+            }
             onClose();
           }}
         >
@@ -167,24 +171,34 @@ export default function ScheduleAction({
           isOutlined={false}
           text={type === ScheduleActionType.ADD ? '추가 완료' : '수정 완료'}
           onClick={() => {
-            const startDate = timePickerToDate(
-              selectedDateFromParent,
-              startTime,
-            );
-            const endDate = timePickerToDate(selectedDateFromParent, endTime);
             const newTodos = todos.filter((todo) => !isEmpty(todo));
             setTodo(newTodos);
-            if (checkNewSchedule(scheduleName, startDate, endDate)) {
-              type === ScheduleActionType.ADD &&
-                postSchedule({
-                  name: scheduleName,
-                  startTime: startDate.toISOString(),
-                  endTime: endDate.toISOString(),
-                  todos: todos,
-                });
-              showToast('일정이 추가되었어요');
-              clearData();
-              onSubmit(true); // 추가 성공여부 파라미터로 받음
+            if (checkNewSchedule(scheduleName, startTime, endTime)) {
+              const sendingData = {
+                name: scheduleName,
+                startTime: startTime.toTimeString(),
+                endTime: endTime.toTimeString(),
+                todos: todos,
+              };
+              type === ScheduleActionType.ADD ?
+                postSchedule(sendingData, {
+                  onSuccess: () => {
+                    showToast('일정이 추가되었어요');
+                    clearData();
+                    onSubmit(true); // 추가 성공여부 파라미터로 받음
+                  },
+                })
+              : editSchedule(
+                  selectedScheduleFromParent.scheduleId ?? -1,
+                  sendingData,
+                  {
+                    onSuccess: () => {
+                      showToast('일정이 수정되었어요');
+                      clearData();
+                      onSubmit(true); // 수정 성공여부 파라미터로 받음
+                    },
+                  },
+                );
             }
           }}
         />

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -41,22 +41,14 @@ export default function ScheduleAction({
   onClose,
   selectedScheduleFromParent,
   selectedDateFromParent,
+  actionInfo,
 }) {
   const { selectedTeam } = useTeam();
   const scrollRef = useRef(null);
-  const {
-    selectedDate,
-    setSelectedDate,
-    scheduleName,
-    setScheduleName,
-    startTime,
-    setStartTime,
-    endTime,
-    setEndTime,
-    todos,
-    setTodo,
-    clearData,
-  } = useScheduleAction(selectedDateFromParent, selectedScheduleFromParent);
+  const { selectedDate, setSelectedDate, clearData } = useScheduleAction(
+    selectedDateFromParent,
+    selectedScheduleFromParent,
+  );
 
   const { mutate: postSchedule } = usePostSchedule(selectedTeam);
   const { mutate: editSchedule } = useEditSchedule(selectedTeam);
@@ -102,6 +94,7 @@ export default function ScheduleAction({
         <button
           onClick={() => {
             if (type !== ScheduleActionType.EDIT) {
+              console.log('CLEAR');
               clearData();
             }
             onClose();
@@ -136,23 +129,27 @@ export default function ScheduleAction({
 
       <CustomInput
         label='일정 이름'
-        content={scheduleName}
-        setContent={setScheduleName}
+        content={actionInfo?.scheduleName ?? ''}
+        setContent={actionInfo?.setScheduleName ?? ''}
         isOutlined={false}
         bgColor='gray-700'
       />
       <div className='h-11 shrink-0' />
 
       <TimeSelector
-        startTime={startTime}
-        setStartTime={setStartTime}
-        endTime={endTime}
-        setEndTime={setEndTime}
+        startTime={actionInfo?.startTime ?? new Date()}
+        setStartTime={actionInfo?.setStartTime}
+        endTime={actionInfo?.endTime ?? new Date()}
+        setEndTime={actionInfo?.setEndTime}
       />
 
       <div className='h-11 shrink-0' />
 
-      <Todo todos={todos} setTodo={setTodo} scrollRef={scrollRef} />
+      <Todo
+        todos={actionInfo?.todos ?? []}
+        setTodo={actionInfo?.setTodo}
+        scrollRef={scrollRef}
+      />
 
       <div className='h-11 shrink-0' />
       <div className='flex-1' />
@@ -164,18 +161,25 @@ export default function ScheduleAction({
           isOutlined={false}
           text={type === ScheduleActionType.ADD ? '추가 완료' : '수정 완료'}
           onClick={() => {
-            const newTodos = todos.filter((todo) => !isEmpty(todo));
-            setTodo(newTodos);
-            if (checkNewSchedule(scheduleName, startTime, endTime)) {
+            const newTodos = actionInfo.todos.filter((todo) => !isEmpty(todo));
+            actionInfo.setTodo(newTodos);
+            if (
+              checkNewSchedule(
+                actionInfo.scheduleName,
+                actionInfo.startTime,
+                actionInfo.endTime,
+              )
+            ) {
               const sendingData = {
-                name: scheduleName,
-                startTime: toKST(startTime).toISOString(),
-                endTime: toKST(endTime).toISOString(),
-                todos: todos,
+                name: actionInfo.scheduleName,
+                startTime: toKST(actionInfo.startTime).toISOString(),
+                endTime: toKST(actionInfo.endTime).toISOString(),
+                todos: actionInfo.todos,
               };
               type === ScheduleActionType.ADD ?
                 postSchedule(sendingData, {
                   onSuccess: () => {
+                    console.log('성공 테스트2');
                     onClose();
                     showToast('일정이 추가되었어요');
                     clearData();

--- a/front-end/src/pages/calendar/components/ScheduleCard.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleCard.jsx
@@ -4,6 +4,7 @@ import Icon from '../../../components/Icon';
 import MediumButton from '../../../components/buttons/MediumButton';
 import { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
+import { useUser } from '../../../useUser';
 
 /**
  *
@@ -19,6 +20,7 @@ export default function ScheduleCard({
   onClickEdit,
   isFinished = false,
 }) {
+  const { userId } = useUser();
   const [isOpen, setIsOpen] = useState(false);
   const contentRef = useRef(null);
   const [height, setHeight] = useState(0);
@@ -31,7 +33,8 @@ export default function ScheduleCard({
   }, [isOpen]);
 
   // 나의 역할 찾기
-  const myRole = todos.find((todo) => todo.memberId === 1)?.task;
+  const myRole = todos.find((todo) => todo.memberId == userId)?.todoList;
+  const teamRole = todos.filter((todo) => todo.memberId != userId);
   return (
     <div
       className={classNames(
@@ -54,7 +57,7 @@ export default function ScheduleCard({
         </div>
         {/* 일정 종료 전에만 수정 버튼 표시 */}
         {!isFinished && (
-          <button onClick={onClickEdit}>
+          <button onClick={() => onClickEdit()}>
             <Icon
               name='edit'
               className={classNames('h-max w-max', schedule.teamName && 'pt-1')}
@@ -85,25 +88,28 @@ export default function ScheduleCard({
         className={`flex flex-col gap-6 overflow-hidden transition-all duration-300 ease-in-out ${isOpen ? 'mb-0' : 'mb-[-24px]'}`}
         style={contentRef.current ? { height: `${height}px` } : { height: 0 }}
       >
-        {todos.map((todo, index) => {
-          //TODO: 내 멤버 id와 비교
-          if (todo.memberId === 1) return null;
-          return (
-            <div key={index} className='flex flex-col gap-3'>
-              <Tag type={TagType.MEMBER_ROLE}>{todo.memberName}</Tag>
-              {todo.todoList.length > 0 ?
-                <div className='flex flex-col gap-1'>
-                  {todo.todoList.map((task, index) => (
-                    <Role key={index}>{task}</Role>
-                  ))}
-                </div>
-              : <p className='body-1 text-gray-500'>
-                  아직 담당 업무를 입력하지 않았어요
-                </p>
-              }
-            </div>
-          );
-        })}
+        {teamRole.length > 0 ?
+          teamRole.map((todo, index) => {
+            return (
+              <div key={index} className='flex flex-col gap-3'>
+                <Tag type={TagType.MEMBER_ROLE}>{todo.memberName}</Tag>
+                {todo.todoList.length > 0 ?
+                  <div className='flex flex-col gap-1'>
+                    {todo.todoList.map((task, index) => (
+                      <Role key={index}>{task}</Role>
+                    ))}
+                  </div>
+                : <p className='body-1 text-gray-500'>
+                    아직 담당 업무를 입력하지 않았어요
+                  </p>
+                }
+              </div>
+            );
+          })
+        : <div className='body-1 text-center text-gray-500'>
+            팀원들이 아직 입력하지 않았어요
+          </div>
+        }
       </div>
       {/* 팀원 역할 보기 토글 버튼 */}
       <MediumButton

--- a/front-end/src/pages/calendar/components/ScheduleDeleteModal.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleDeleteModal.jsx
@@ -2,11 +2,11 @@ import MediumButton from '../../../components/buttons/MediumButton';
 import Modal, { ModalType } from '../../../components/modals/Modal';
 import { hideModal } from '../../../utility/handleModal';
 
-export default function ScheduleDeleteModal({ onClose }) {
+export default function ScheduleDeleteModal({ deleteSchedule, onClose }) {
   return (
     <Modal
       type={ModalType.DOUBLE}
-      content='정말 삭제하시겠어요?'
+      content='일정을 삭제하시겠어요?'
       subButton={
         <MediumButton
           text='취소'
@@ -21,8 +21,7 @@ export default function ScheduleDeleteModal({ onClose }) {
           text='삭제'
           isOutlined={false}
           onClick={() => {
-            // TODO: 일정 삭제
-            hideModal();
+            deleteSchedule();
             onClose();
           }}
         />

--- a/front-end/src/pages/calendar/components/TimeSelector.jsx
+++ b/front-end/src/pages/calendar/components/TimeSelector.jsx
@@ -18,13 +18,15 @@ export default function TimeSelector({
       <div className='flex items-center gap-3'>
         <DropdownLarge
           triggerText={startText}
-          setTriggerText={(text) => setStartTime(timeStringToDate(text))}
+          setTriggerText={(text) =>
+            setStartTime(timeStringToDate(startTime, text))
+          }
           isFromTime={true}
           items={timeOptions}
         />
         <DropdownLarge
           triggerText={endText}
-          setTriggerText={(text) => setEndTime(timeStringToDate(text))}
+          setTriggerText={(text) => setEndTime(timeStringToDate(endTime, text))}
           isFromTime={false}
           items={timeOptions}
         />
@@ -33,9 +35,9 @@ export default function TimeSelector({
   );
 }
 
-function timeStringToDate(timeString) {
+function timeStringToDate(selectedDate, timeString) {
   const [hours, minutes] = timeString.split(':').map(Number); // "02:10" → [2, 10]
-  const date = new Date(); // 현재 날짜
+  const date = new Date(selectedDate); // 현재 날짜
   date.setHours(hours, minutes, 0, 0); // 시, 분, 초, 밀리초 설정
   return date;
 }

--- a/front-end/src/pages/calendar/components/TimeSelector.jsx
+++ b/front-end/src/pages/calendar/components/TimeSelector.jsx
@@ -7,23 +7,35 @@ export default function TimeSelector({
   endTime,
   setEndTime,
 }) {
+  const startText = new Date(startTime)
+    .toTimeString()
+    .split(' ')[0]
+    .slice(0, 5);
+  const endText = new Date(endTime).toTimeString().split(' ')[0].slice(0, 5);
   return (
     <div className='flex flex-col gap-2'>
       <h3 className='subtitle-2 text-gray-0'>일정 시간</h3>
       <div className='flex items-center gap-3'>
         <DropdownLarge
-          triggerText={startTime}
-          setTriggerText={setStartTime}
+          triggerText={startText}
+          setTriggerText={(text) => setStartTime(timeStringToDate(text))}
           isFromTime={true}
           items={timeOptions}
         />
         <DropdownLarge
-          triggerText={endTime}
-          setTriggerText={setEndTime}
+          triggerText={endText}
+          setTriggerText={(text) => setEndTime(timeStringToDate(text))}
           isFromTime={false}
           items={timeOptions}
         />
       </div>
     </div>
   );
+}
+
+function timeStringToDate(timeString) {
+  const [hours, minutes] = timeString.split(':').map(Number); // "02:10" → [2, 10]
+  const date = new Date(); // 현재 날짜
+  date.setHours(hours, minutes, 0, 0); // 시, 분, 초, 밀리초 설정
+  return date;
 }

--- a/front-end/src/pages/calendar/components/TodoAdd.jsx
+++ b/front-end/src/pages/calendar/components/TodoAdd.jsx
@@ -6,6 +6,7 @@ import StickyWrapper from '../../../components/wrappers/StickyWrapper';
 import { showToast } from '../../../utility/handleToast';
 import { isEmpty } from '../../../utility/inputChecker';
 import Todo from './Todo';
+import { useUser } from '../../../useUser';
 
 /**
  * 일정 추가 페이지
@@ -21,9 +22,10 @@ export default function TodoAdd({
   onSubmit,
   selectedSchedule,
 }) {
+  const { userId } = useUser();
   const [todos, setTodo] = useState(
     selectedSchedule?.todos?.filter((todo) => {
-      return todo.memberId === 1;
+      return todo.memberId == userId;
     }).task ?? [],
   );
   const scrollRef = useRef(null);
@@ -31,7 +33,7 @@ export default function TodoAdd({
   useEffect(() => {
     const newTodos =
       selectedSchedule?.todos?.find((todo) => {
-        return todo.memberId === 1;
+        return todo.memberId == userId;
       })?.task ?? [];
     setTodo(newTodos);
   }, [selectedSchedule]);

--- a/front-end/src/pages/calendar/components/TodoAdd.jsx
+++ b/front-end/src/pages/calendar/components/TodoAdd.jsx
@@ -1,11 +1,10 @@
 import classNames from 'classnames';
 import Icon from '../../../components/Icon';
 import { useEffect, useRef, useState } from 'react';
-import { changeDayName, timePickerToDate } from '../../../utility/time';
 import LargeButton from '../../../components/buttons/LargeButton';
 import StickyWrapper from '../../../components/wrappers/StickyWrapper';
 import { showToast } from '../../../utility/handleToast';
-import { checkNewSchedule, isEmpty } from '../../../utility/inputChecker';
+import { isEmpty } from '../../../utility/inputChecker';
 import Todo from './Todo';
 
 /**

--- a/front-end/src/pages/calendar/hooks/useSchedule.jsx
+++ b/front-end/src/pages/calendar/hooks/useSchedule.jsx
@@ -5,6 +5,9 @@ export default function useSchedule(teamId, selectedDate) {
   const [allSchedules, setAllSchedules] = useState([]);
   const [scheduleOnDate, setScheduleOnDate] = useState(null);
   const [scheduleSet, setScheduleSet] = useState(new Set());
+  const [selectedSchedule, setSelectedSchedule] = useState(
+    scheduleOnDate ? scheduleOnDate[0] : null,
+  );
 
   // 해당 날짜에 있는 스케줄 필터링
   useEffect(() => {
@@ -41,5 +44,7 @@ export default function useSchedule(teamId, selectedDate) {
     setAllSchedules,
     scheduleOnDate,
     scheduleSet,
+    selectedSchedule,
+    setSelectedSchedule,
   };
 }

--- a/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
+++ b/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
@@ -20,9 +20,9 @@ export default function useScheduleAction(date, selectedSchedule) {
     new Date(selectedSchedule?.endTime ?? new Date(date).setHours(12, 0, 0, 0)),
   );
   const [todos, setTodo] = useState(
-    selectedSchedule?.todos?.filter((todo) => {
-      return todo.memberId === userId;
-    }).task ?? [],
+    selectedSchedule?.scheduleMemberNestedDtoList?.find(
+      (dtoList) => dtoList.memberId == userId,
+    )?.todoList ?? [],
   );
 
   useEffect(() => {
@@ -42,9 +42,10 @@ export default function useScheduleAction(date, selectedSchedule) {
       ),
     );
     const newTodos =
-      selectedSchedule?.todos?.find((todo) => {
-        return todo.memberId === userId;
-      })?.task ?? [];
+      selectedSchedule?.scheduleMemberNestedDtoList?.find(
+        (dtoList) => dtoList.memberId == userId,
+      )?.todoList ?? [];
+    // console.log(newTodos);
     setTodo(newTodos);
   }, [selectedSchedule]);
 

--- a/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
+++ b/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
@@ -16,6 +16,7 @@ export default function useScheduleAction(date, selectedSchedule) {
       selectedSchedule?.startTime ?? new Date(date).setHours(12, 0, 0, 0),
     ),
   );
+  // console.log(startTime);
   const [endTime, setEndTime] = useState(
     new Date(selectedSchedule?.endTime ?? new Date(date).setHours(12, 0, 0, 0)),
   );
@@ -27,9 +28,7 @@ export default function useScheduleAction(date, selectedSchedule) {
 
   useEffect(() => {
     setSelectedDate(date);
-  }, [date]);
 
-  useEffect(() => {
     setScheduleName(selectedSchedule?.scheduleName ?? '');
     setStartTime(
       new Date(
@@ -45,9 +44,9 @@ export default function useScheduleAction(date, selectedSchedule) {
       selectedSchedule?.scheduleMemberNestedDtoList?.find(
         (dtoList) => dtoList.memberId == userId,
       )?.todoList ?? [];
-    // console.log(newTodos);
     setTodo(newTodos);
-  }, [selectedSchedule]);
+  }, [date, selectedSchedule]);
+  // 날짜 바꿔서 일정 만들때 startTime, endTime 제대로 설정하려면 date가 의존성배열에 포함되어야 함
 
   return {
     doingAction,

--- a/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
+++ b/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
@@ -4,7 +4,6 @@ import { useUser } from '../../../useUser';
 
 export default function useScheduleAction(date, selectedSchedule) {
   const { userId } = useUser();
-  const [refresh, setRefresh] = useState(false);
   const [doingAction, setDoingAction] = useState(false);
   const [actionType, setActionType] = useState(ScheduleActionType.ADD);
 
@@ -28,10 +27,9 @@ export default function useScheduleAction(date, selectedSchedule) {
 
   const clearData = () => {
     setScheduleName('');
-    setStartTime(new Date(new Date(date).setHours(12, 0, 0, 0)));
-    setEndTime(new Date(new Date(date).setHours(12, 0, 0, 0)));
+    setStartTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
+    setEndTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
     setTodo([]);
-    setRefresh((prev) => !prev); // 강제 리렌더링
   };
 
   useEffect(() => {
@@ -63,15 +61,16 @@ export default function useScheduleAction(date, selectedSchedule) {
     setActionType,
     selectedDate,
     setSelectedDate,
-    scheduleName,
-    setScheduleName,
-    startTime,
-    setStartTime,
-    endTime,
-    setEndTime,
-    todos,
-    setTodo,
+    actionInfo: {
+      scheduleName,
+      setScheduleName,
+      startTime,
+      setStartTime,
+      endTime,
+      setEndTime,
+      todos,
+      setTodo,
+    },
     clearData,
-    refresh,
   };
 }

--- a/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
+++ b/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
@@ -4,6 +4,7 @@ import { useUser } from '../../../useUser';
 
 export default function useScheduleAction(date, selectedSchedule) {
   const { userId } = useUser();
+  const [refresh, setRefresh] = useState(false);
   const [doingAction, setDoingAction] = useState(false);
   const [actionType, setActionType] = useState(ScheduleActionType.ADD);
 
@@ -16,7 +17,6 @@ export default function useScheduleAction(date, selectedSchedule) {
       selectedSchedule?.startTime ?? new Date(date).setHours(12, 0, 0, 0),
     ),
   );
-  // console.log(startTime);
   const [endTime, setEndTime] = useState(
     new Date(selectedSchedule?.endTime ?? new Date(date).setHours(12, 0, 0, 0)),
   );
@@ -25,6 +25,14 @@ export default function useScheduleAction(date, selectedSchedule) {
       (dtoList) => dtoList.memberId == userId,
     )?.todoList ?? [],
   );
+
+  const clearData = () => {
+    setScheduleName('');
+    setStartTime(new Date(new Date(date).setHours(12, 0, 0, 0)));
+    setEndTime(new Date(new Date(date).setHours(12, 0, 0, 0)));
+    setTodo([]);
+    setRefresh((prev) => !prev); // 강제 리렌더링
+  };
 
   useEffect(() => {
     setSelectedDate(date);
@@ -63,5 +71,7 @@ export default function useScheduleAction(date, selectedSchedule) {
     setEndTime,
     todos,
     setTodo,
+    clearData,
+    refresh,
   };
 }

--- a/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
+++ b/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
@@ -1,9 +1,67 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ScheduleActionType } from '../components/ScheduleAction';
+import { useUser } from '../../../useUser';
 
-export default function useScheduleAction() {
+export default function useScheduleAction(date, selectedSchedule) {
+  const { userId } = useUser();
   const [doingAction, setDoingAction] = useState(false);
   const [actionType, setActionType] = useState(ScheduleActionType.ADD);
 
-  return { doingAction, setDoingAction, actionType, setActionType };
+  const [selectedDate, setSelectedDate] = useState(new Date(date));
+  const [scheduleName, setScheduleName] = useState(
+    selectedSchedule?.scheduleName ?? '',
+  );
+  const [startTime, setStartTime] = useState(
+    new Date(
+      selectedSchedule?.startTime ?? new Date(date).setHours(12, 0, 0, 0),
+    ),
+  );
+  const [endTime, setEndTime] = useState(
+    new Date(selectedSchedule?.endTime ?? new Date(date).setHours(12, 0, 0, 0)),
+  );
+  const [todos, setTodo] = useState(
+    selectedSchedule?.todos?.filter((todo) => {
+      return todo.memberId === userId;
+    }).task ?? [],
+  );
+
+  useEffect(() => {
+    setSelectedDate(date);
+  }, [date]);
+
+  useEffect(() => {
+    setScheduleName(selectedSchedule?.scheduleName ?? '');
+    setStartTime(
+      new Date(
+        selectedSchedule?.startTime ?? new Date(date).setHours(12, 0, 0, 0),
+      ),
+    );
+    setEndTime(
+      new Date(
+        selectedSchedule?.endTime ?? new Date(date).setHours(12, 0, 0, 0),
+      ),
+    );
+    const newTodos =
+      selectedSchedule?.todos?.find((todo) => {
+        return todo.memberId === userId;
+      })?.task ?? [];
+    setTodo(newTodos);
+  }, [selectedSchedule]);
+
+  return {
+    doingAction,
+    setDoingAction,
+    actionType,
+    setActionType,
+    selectedDate,
+    setSelectedDate,
+    scheduleName,
+    setScheduleName,
+    startTime,
+    setStartTime,
+    endTime,
+    setEndTime,
+    todos,
+    setTodo,
+  };
 }

--- a/front-end/src/utility/time.js
+++ b/front-end/src/utility/time.js
@@ -141,7 +141,9 @@ export function timePickerToDate(date, time) {
 }
 
 export function toKST(date) {
-  return new Date(new Date(date).setHours(9, 0, 0, 0));
+  let kst = new Date(date);
+  kst.setTime(new Date(date).getTime() + 1000 * 60 * 60 * 9);
+  return kst;
 }
 
 /**


### PR DESCRIPTION
일정 추가 삭제 API 적용 완료했습니다.
- 팀 목록 불러오기 API 적용
- 일정 관련 커스텀훅들을 분리
   - useSchedule : 스케줄 전체 목록, 사용자가 선택한 스케줄, 스케줄이 있는 날짜 등을 관리하는 훅
   - useScheduleAction : 스케줄 추가, 수정 + 스케줄 내용을 관리하는 훅
- 일정 추가하다가 창 닫으면 내용 비움 (수정일땐 안비우며, 일정이 바뀌면 그 일정 내용으로 대체함)

이후 생기는 버그들은 추가적으로 수정하겠습니다

<img width="430" alt="스크린샷 2025-02-12 오후 2 13 20" src="https://github.com/user-attachments/assets/3a5f0728-f7f6-41a2-9e0c-ae8bfed6224c" />
<img width="430" alt="스크린샷 2025-02-12 오후 2 13 41" src="https://github.com/user-attachments/assets/15cb7fee-9d54-4812-af97-1cfd4c1ae3a9" />
<img width="430" alt="스크린샷 2025-02-12 오후 2 13 32" src="https://github.com/user-attachments/assets/d95fec05-d39b-4e8e-8a07-6feadf7be44b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled schedule deletion functionality with improved user interactions.
  - Enhanced time selection with clear, formatted display and precise conversion.

- **Improvements**
  - Refined API response handling to offer a more stable experience.
  - Streamlined calendar operations including schedule registration, editing, and confirmation dialogs.
  - Updated team and task displays for dynamic, accurate user-specific information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->