### PR TITLE
[FD-329] feat: cors 설정을 쉼표로 구분하는 링크 문자열로 받도록 설정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
@@ -42,7 +42,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins(allowedOrigins)
+                .allowedOrigins(allowedOrigins.split(","))
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/config/WebConfig.java
@@ -1,7 +1,9 @@
 package com.feedhanjum.back_end.auth.config;
 
+import com.feedhanjum.back_end.auth.config.property.CorsProperties;
 import com.feedhanjum.back_end.auth.infra.AuthInterceptor;
 import com.feedhanjum.back_end.auth.infra.LoginMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.apache.catalina.Context;
 import org.apache.catalina.connector.Connector;
 import org.apache.tomcat.util.descriptor.web.SecurityCollection;
@@ -18,10 +20,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    @Value("${cors.allowed-origins}")
-    private String allowedOrigins;
+    private final CorsProperties corsProperties;
 
     @Value("${server.http.port}")
     private int httpPort;
@@ -42,7 +44,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins(allowedOrigins.split(","))
+                .allowedOrigins(corsProperties.getAllowedOrigins().toArray(new String[0]))
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/config/property/CorsProperties.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/config/property/CorsProperties.java
@@ -1,0 +1,15 @@
+package com.feedhanjum.back_end.auth.config.property;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@ConfigurationProperties(prefix = "cors")
+@Getter
+public class CorsProperties {
+    private final List<String> allowedOrigins = new ArrayList<>();
+}


### PR DESCRIPTION
# 관련 이슈
FD-329

# 변경 내용
- [x] CorsProperties 정의
- [x] cors 설정 배열로 받아 저장
- [x] cors 설정에 localhost, feedhanjum 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced cross-origin resource sharing (CORS) support, offering more flexible domain management for improved integration.

- **Refactor**
  - Streamlined CORS configuration by centralizing settings, resulting in improved maintainability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->