### PR TITLE
[FD-300] 레디스 세션 적용

### DIFF
--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -45,6 +45,11 @@ dependencies {
     implementation 'org.bouncycastle:bcprov-jdk18on:1.80'
 
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'com.github.codemonstur:embedded-redis:1.4.2'
+
     //Querydsl 추가
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
@@ -55,3 +60,4 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/domain/EmailSignupToken.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/domain/EmailSignupToken.java
@@ -4,11 +4,15 @@ package com.feedhanjum.back_end.auth.domain;
 import com.feedhanjum.back_end.auth.exception.SignupTokenNotValidException;
 import lombok.Getter;
 
+import java.io.Serial;
 import java.time.LocalDateTime;
 import java.util.Random;
 
 @Getter
-public class EmailSignupToken {
+public class EmailSignupToken implements java.io.Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public static final int TOKEN_LENGTH = 4;
     public static final int EXPIRE_MINUTE = 5;
     private final String email;

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/domain/GoogleSignupToken.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/domain/GoogleSignupToken.java
@@ -3,11 +3,15 @@ package com.feedhanjum.back_end.auth.domain;
 import com.feedhanjum.back_end.auth.exception.SignupTokenNotValidException;
 import lombok.Getter;
 
+import java.io.Serial;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
-public class GoogleSignupToken {
+public class GoogleSignupToken implements java.io.Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public static final int TOKEN_LENGTH = 36;
     public static final int EXPIRE_MINUTE = 10;
     private final String email;

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/domain/PasswordResetToken.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/domain/PasswordResetToken.java
@@ -3,11 +3,16 @@ package com.feedhanjum.back_end.auth.domain;
 import com.feedhanjum.back_end.auth.exception.PasswordResetTokenNotValidException;
 import lombok.Getter;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Random;
 
 @Getter
-public class PasswordResetToken {
+public class PasswordResetToken implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
     public static final int TOKEN_LENGTH = 4;
     public static final int EXPIRE_MINUTE = 5;
     private final String email;

--- a/back-end/src/main/java/com/feedhanjum/back_end/core/config/RedisConfig.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/config/RedisConfig.java
@@ -1,0 +1,50 @@
+package com.feedhanjum.back_end.core.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+@Slf4j
+@Profile({"dev", "prod"})
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisSerializer<Object> springSessionDefaultRedisSerializer() {
+        return new JdkSerializationRedisSerializer();
+
+    }
+
+
+    @Configuration
+    @Profile(("dev"))
+    static class EmbeddedRedisConfig {
+        private final RedisServer redisServer;
+
+        public EmbeddedRedisConfig(@Value("${spring.data.redis.port}") int port) throws IOException {
+            log.info("Embedded redis server is ready for port {}", port);
+            this.redisServer = new RedisServer(port);
+        }
+
+        @PostConstruct
+        public void postConstruct() throws IOException {
+            log.info("Embedded redis server starting");
+            redisServer.start();
+        }
+
+        @PreDestroy
+        public void preDestroy() throws IOException {
+            log.info("Embedded redis server stopping");
+            redisServer.stop();
+        }
+    }
+}

--- a/back-end/src/main/resources/application.yml
+++ b/back-end/src/main/resources/application.yml
@@ -15,11 +15,15 @@ spring:
           timeout: 5000
           starttls:
             enable: true
+  session:
+    timeout: 2147483647
+    redis:
+      save-mode: always
+      flush-mode: immediate
 
 springdoc:
   swagger-ui:
     path: /swagger # swagger-ui 접근 경로. 해당 경로로 접근 시 /swagger/index.html로 리다이렉션 됨
-
 
 
 server:
@@ -27,3 +31,5 @@ server:
     session:
       cookie:
         max-age: 2147483647
+        http-only: true
+        name: JSESSIONID

--- a/back-end/src/test/resources/application-test.yml
+++ b/back-end/src/test/resources/application-test.yml
@@ -9,7 +9,9 @@ spring:
       ddl-auto: create
     database-platform: org.hibernate.dialect.H2Dialect
   autoconfigure:
-    exclude: org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration
+    exclude:
+      - org.springframework.boot.autoconfigure.mail.MailSenderAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
 
 server:
   http.port: 80


### PR DESCRIPTION
# 관련 이슈
FD-300

# 변경된 점
- 레디스를 세션 저장소로 사용
  - dev 환경에서는 임베디드 레디스 서버를 실행하도록 관련 라이브러리 추가
  - test 환경에서는 Servlet Session을 사용하도록 레디스 자동설정 제외
- 세션에 저장될 객체는 직렬화를 위해 Serializable을 구현하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated Redis support to enhance session persistence, caching, and secure cookie handling for a smoother experience.

- **Refactor**
  - Streamlined authentication flows and token management with improved logging for better traceability during registration and login.

- **Tests**
  - Expanded integration tests to verify event notifications during team membership changes and refined test configurations for increased stability.

- **Chores**
  - Updated dependencies and configuration settings to optimize backend operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->