### PR TITLE
[FD-333]  팀 스페이스 종료 날짜가 현재보다 미래가 되도록 수정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type", discriminatorType = DiscriminatorType.STRING)
 @Entity
-public class InAppNotification {
+public abstract class InAppNotification {
     @Id
     @Column(name = "notification_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
@@ -8,6 +8,7 @@ import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.schedule.domain.Schedule;
 import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
 import com.feedhanjum.back_end.schedule.event.ScheduleEndedEvent;
 import com.feedhanjum.back_end.schedule.exception.ScheduleAlreadyExistException;
 import com.feedhanjum.back_end.schedule.exception.ScheduleIsAlreadyEndException;
@@ -82,6 +83,7 @@ public class ScheduleService {
         memberQueryRepository.findMembersByTeamId(teamId).forEach(m -> scheduleMemberRepository.save(new ScheduleMember(schedule, m)));
         ScheduleMember scheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, schedule.getId()).orElseThrow(() -> new RuntimeException("내부 서버 에러: 방금 조회한 사용자 ID가 사라짐"));
         scheduleMember.setTodos(requestDto.todos());
+        eventPublisher.publishEvent(new ScheduleCreatedEvent(schedule.getId()));
     }
 
     /**

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -42,8 +42,8 @@ public class Team {
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<FrequentFeedbackRequest> frequentFeedbackRequests = new ArrayList<>();
 
-    public Team(String name, Member leader, LocalDate startDate, LocalDate endDate, FeedbackType feedbackType) {
-        validateDuration(startDate, endDate);
+    public Team(String name, Member leader, LocalDate startDate, LocalDate endDate, FeedbackType feedbackType, LocalDate now) {
+        validateDuration(startDate, endDate, now);
         this.feedbackType = feedbackType;
         this.name = name;
         this.startDate = startDate;
@@ -59,9 +59,9 @@ public class Team {
         this.leader = newLeader;
     }
 
-    public void updateInfo(Member leader, String name, LocalDate startDate, LocalDate endDate, FeedbackType feedbackType) {
+    public void updateInfo(Member leader, String name, LocalDate startDate, LocalDate endDate, FeedbackType feedbackType, LocalDate now) {
         validateTeamLeader(leader);
-        validateDuration(startDate, endDate);
+        validateDuration(startDate, endDate, now);
         this.name = name;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -154,9 +154,12 @@ public class Team {
             throw new TeamMembershipNotFoundException("팀원이 아닙니다");
     }
 
-    private void validateDuration(LocalDate startDate, LocalDate endDate) {
+    private void validateDuration(LocalDate startDate, LocalDate endDate, LocalDate now) {
         if (endDate != null && !startDate.isBefore(endDate)) {
             throw new IllegalArgumentException("프로젝트 시작 시간이 종료 시간보다 앞서야 합니다.");
+        }
+        if(endDate != null && endDate.isBefore(now)){
+            throw new IllegalArgumentException("프로젝트 종료 날짜는 오늘 이후여야 합니다.");
         }
     }
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -33,6 +35,7 @@ public class TeamService {
     private final EventPublisher eventPublisher;
     private final TeamJoinTokenRepository teamJoinTokenRepository;
     private final ScheduleQueryRepository scheduleQueryRepository;
+    private final Clock clock;
 
     /**
      * @throws IllegalArgumentException 프로젝트 기간의 시작일이 종료일보다 앞서지 않을 경우
@@ -42,7 +45,7 @@ public class TeamService {
     public Team createTeam(Long leaderId, TeamCreateDto teamCreateDto) {
         Member leader = memberRepository.findById(leaderId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
-        Team team = new Team(teamCreateDto.teamName(), leader, teamCreateDto.startDate(), teamCreateDto.endDate(), teamCreateDto.feedbackType());
+        Team team = new Team(teamCreateDto.teamName(), leader, teamCreateDto.startDate(), teamCreateDto.endDate(), teamCreateDto.feedbackType(), LocalDate.now(clock));
         teamRepository.save(team);
         return team;
     }
@@ -120,7 +123,7 @@ public class TeamService {
             throw new IllegalArgumentException("팀 종료 날짜는 팀 내 존재하는 일정의 가장 늦은 종료 시점보다 느릴 수 없습니다.");
         }
 
-        team.updateInfo(leader, teamUpdateDto.teamName(), teamUpdateDto.startDate(), teamUpdateDto.endDate(), teamUpdateDto.feedbackType());
+        team.updateInfo(leader, teamUpdateDto.teamName(), teamUpdateDto.startDate(), teamUpdateDto.endDate(), teamUpdateDto.feedbackType(), LocalDate.now(clock));
         return team;
     }
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -6,6 +6,7 @@ import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleQueryRepository;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamJoinToken;
+import com.feedhanjum.back_end.team.event.TeamLeaderChangedEvent;
 import com.feedhanjum.back_end.team.event.TeamMemberJoinEvent;
 import com.feedhanjum.back_end.team.event.TeamMemberLeftEvent;
 import com.feedhanjum.back_end.team.exception.TeamLeaderMustExistException;
@@ -91,6 +92,7 @@ public class TeamService {
         Member newLeader = memberRepository.findById(newLeaderId).orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
 
         team.changeLeader(currentLeader, newLeader);
+        eventPublisher.publishEvent(new TeamLeaderChangedEvent(teamId, newLeaderId));
     }
 
     /**

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/FeedbackControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/FeedbackControllerTest.java
@@ -88,7 +88,7 @@ class FeedbackControllerTest {
     }
 
     private Team createTeam(String name, Member leader) {
-        return new Team(name, leader, LocalDate.now(clock).minusDays(1), LocalDate.now(clock).plusDays(1), FeedbackType.ANONYMOUS);
+        return new Team(name, leader, LocalDate.now(clock).minusDays(1), LocalDate.now(clock).plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now(clock));
     }
 
     private Schedule createSchedule(String name, Team team, Member leader, boolean isEnd) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/RetrospectControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/RetrospectControllerTest.java
@@ -71,7 +71,7 @@ class RetrospectControllerTest {
     }
 
     private Team createTeam(String name, Member leader) {
-        return new Team(name, leader, LocalDate.now(clock).minusDays(1), LocalDate.now(clock).plusDays(1), FeedbackType.ANONYMOUS);
+        return new Team(name, leader, LocalDate.now(clock).minusDays(1), LocalDate.now(clock).plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now(clock));
     }
 
     private Retrospect createRetrospect(String title, Member writer, Team team) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/repository/FeedbackQueryRepositoryTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/repository/FeedbackQueryRepositoryTest.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -98,8 +99,8 @@ class FeedbackQueryRepositoryTest {
             member2 = new Member("member2", "email2@email.com", new ProfileImage("bg1", "profile1"), feedbackPreferences);
             memberRepository.saveAll(List.of(member1, member2));
 
-            team1 = new Team("team1", member1, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS);
-            team2 = new Team("team2", member2, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS);
+            team1 = new Team("team1", member1, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS, LocalDate.now());
+            team2 = new Team("team2", member2, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS, LocalDate.now());
             teamRepository.saveAll(List.of(team1, team2));
         }
 
@@ -294,8 +295,8 @@ class FeedbackQueryRepositoryTest {
             member2 = new Member("member2", "email2@email.com", new ProfileImage("bg1", "profile1"), feedbackPreferences);
             memberRepository.saveAll(List.of(member1, member2));
 
-            team1 = new Team("team1", member1, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS);
-            team2 = new Team("team2", member2, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS);
+            team1 = new Team("team1", member1, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS, LocalDate.now());
+            team2 = new Team("team2", member2, LocalDateTime.now().minusDays(1).toLocalDate(), LocalDateTime.now().plusDays(1).toLocalDate(), FeedbackType.ANONYMOUS, LocalDate.now());
             teamRepository.saveAll(List.of(team1, team2));
         }
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -83,7 +83,7 @@ class FeedbackServiceTest {
     }
 
     private Team createTeam(String name, Member leader) {
-        Team team = new Team(name, leader, LocalDate.now(clock).minusDays(1), LocalDate.now(clock).plusDays(1), FeedbackType.ANONYMOUS);
+        Team team = new Team(name, leader, LocalDate.now(clock).minusDays(1), LocalDate.now(clock).plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now(clock));
         ReflectionTestUtils.setField(team, "id", nextId.getAndIncrement());
         return team;
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/RetrospectServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/RetrospectServiceTest.java
@@ -54,7 +54,7 @@ class RetrospectServiceTest {
     }
 
     private Team createTeam(String teamName, Member leader) {
-        Team team = new Team(teamName, leader, LocalDate.now(), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS);
+        Team team = new Team(teamName, leader, LocalDate.now(), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now());
         ReflectionTestUtils.setField(team, "id", nextId.getAndIncrement());
         return team;
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/notification/controller/InAppNotificationControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/notification/controller/InAppNotificationControllerTest.java
@@ -71,7 +71,7 @@ class InAppNotificationControllerTest {
     }
 
     private Team createTeam(String name, Member leader) {
-        return new Team(name, leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS);
+        return new Team(name, leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now());
     }
 
     private InAppNotification createInAppNotification(Member receiver, Team team) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/schedule/service/ScheduleServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/schedule/service/ScheduleServiceTest.java
@@ -1,11 +1,13 @@
 package com.feedhanjum.back_end.schedule.service;
 
+import com.feedhanjum.back_end.event.EventPublisher;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.schedule.domain.Schedule;
 import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
 import com.feedhanjum.back_end.schedule.domain.Todo;
+import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
 import com.feedhanjum.back_end.schedule.exception.ScheduleAlreadyExistException;
 import com.feedhanjum.back_end.schedule.exception.ScheduleIsAlreadyEndException;
 import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
@@ -56,6 +58,9 @@ class ScheduleServiceTest {
 
     @Mock
     ScheduleQueryRepository scheduleQueryRepository;
+
+    @Mock
+    EventPublisher eventPublisher;
 
     @Mock
     MemberQueryRepository memberQueryRepository;
@@ -115,6 +120,7 @@ class ScheduleServiceTest {
 
         // then
         verify(scheduleMember, times(1)).setTodos(List.of(hehe));
+        verify(eventPublisher).publishEvent(new ScheduleCreatedEvent(schedule.getId()));
     }
 
     @Test

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
@@ -60,7 +60,7 @@ class TeamControllerTest {
                 endDate, FeedbackType.ANONYMOUS, new MemberDto(new Member("haha", "haha@hoho", null, feedbackPreferences)));
         when(teamService.createTeam(memberId, teamCreateDto))
                 .thenReturn(new Team("haha", new Member("haha", "haha@hoho", null, feedbackPreferences),
-                        request.startDate(), request.endDate(), request.feedbackType()));
+                        request.startDate(), request.endDate(), request.feedbackType(), LocalDate.now()));
 
         //when
         ResponseEntity<TeamResponse> response = teamController.createTeam(memberId, request);
@@ -78,7 +78,7 @@ class TeamControllerTest {
         Long memberId = 1L;
         List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
         Team team = new Team("haha", new Member("haha", "haha@hoho", null, feedbackPreferences), LocalDate.now().plusDays(1),
-                LocalDate.now().plusDays(10), FeedbackType.ANONYMOUS);
+                LocalDate.now().plusDays(10), FeedbackType.ANONYMOUS, LocalDate.now());
         TeamResponse teamResponse = new TeamResponse(team);
         when(teamService.getMyTeams(memberId)).thenReturn(List.of(team));
 
@@ -101,7 +101,7 @@ class TeamControllerTest {
 
         List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
         Member leader = new Member("haha", "haha", null, feedbackPreferences);
-        Team dummyTeam = new Team("haha", leader, now, now.plusDays(1), FeedbackType.IDENTIFIED);
+        Team dummyTeam = new Team("haha", leader, now, now.plusDays(1), FeedbackType.IDENTIFIED, LocalDate.now());
 
         Member dummyMember = new Member("hoho", "huhu", null, feedbackPreferences);
         List<Member> memberList = List.of(dummyMember);
@@ -212,7 +212,7 @@ class TeamControllerTest {
         Long memberId = 100L;
         TeamUpdateRequest teamUpdateRequest = new TeamUpdateRequest("hehe", LocalDate.now().plusDays(1), LocalDate.now().plusDays(10), FeedbackType.IDENTIFIED);
 
-        Team team = new Team("haha", mock(Member.class), LocalDate.now().plusDays(1), LocalDate.now().plusDays(10), FeedbackType.ANONYMOUS);
+        Team team = new Team("haha", mock(Member.class), LocalDate.now().plusDays(1), LocalDate.now().plusDays(10), FeedbackType.ANONYMOUS, LocalDate.now());
         when(teamService.updateTeamInfo(memberId, teamId, new TeamUpdateDto(teamUpdateRequest))).thenReturn(team);
 
         // when

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/domain/TeamTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/domain/TeamTest.java
@@ -35,7 +35,7 @@ class TeamTest {
 
 
         // when
-        Team team = new Team("team1", leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS);
+        Team team = new Team("team1", leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now());
 
         // then
         assertThat(team.isTeamMember(leader)).isTrue();
@@ -46,7 +46,7 @@ class TeamTest {
     void changeLeader_성공() {
         // given
         Member currentLeader = createMember("currentLeader");
-        Team team = new Team("team1", currentLeader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS);
+        Team team = new Team("team1", currentLeader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now());
         Member newLeader = createMember("newLeader");
         team.join(newLeader);
 
@@ -62,7 +62,7 @@ class TeamTest {
     void changeLeader_실패() {
         // given
         Member currentLeader = createMember("currentLeader");
-        Team team = new Team("team1", currentLeader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS);
+        Team team = new Team("team1", currentLeader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now());
         Member notLeader = createMember("notLeader");
         Member newLeader = createMember("newLeader");
         team.join(notLeader);
@@ -81,7 +81,7 @@ class TeamTest {
     void changeLeader_실패2() {
         // given
         Member currentLeader = createMember("currentLeader");
-        Team team = new Team("team1", currentLeader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS);
+        Team team = new Team("team1", currentLeader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), FeedbackType.ANONYMOUS, LocalDate.now());
         Member newLeader = createMember("newLeader");
 
         // when

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/service/TeamServiceTest.java
@@ -71,7 +71,7 @@ class TeamServiceTest {
         when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
         List<FeedbackPreference> feedbackPreferences = List.of(FeedbackPreference.PROGRESSIVE, FeedbackPreference.COMPLEMENTING);
         Member leader = new Member("haha", "haha@hoho", new ProfileImage("blue", "image1"), feedbackPreferences);
-        Team team = new Team("haha", leader, LocalDate.now(clock).plusDays(1), LocalDate.now(clock).plusDays(10), FeedbackType.ANONYMOUS);
+        Team team = new Team("haha", leader, LocalDate.now(clock).plusDays(1), LocalDate.now(clock).plusDays(10), FeedbackType.ANONYMOUS, LocalDate.now(clock));
         when(teamQueryRepository.findTeamByMemberId(userId)).thenReturn(List.of(team));
 
         //when
@@ -378,10 +378,12 @@ class TeamServiceTest {
         void updateTeamInfo_성공() {
             // given
             Member leader = createMemberWithId("leader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
             LocalDate startDate = LocalDate.of(2025, 1, 1);
             LocalDate endDate = LocalDate.of(2025, 1, 2);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
-            Team team = createTeamWithId("team", leader, startDate, endDate);
+            Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
             when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
@@ -401,6 +403,8 @@ class TeamServiceTest {
         void updateTeamInfo_잘못된기간() {
             // given
             Member member = createMemberWithId("member");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
             LocalDate startDate = LocalDate.of(2025, 1, 3);
             LocalDate endDate = LocalDate.of(2025, 1, 2);
             Team team = createTeamWithId("team", member);
@@ -437,9 +441,11 @@ class TeamServiceTest {
         void updateTeamInfo_팀장아님() {
             // given
             Member notLeader = createMemberWithId("notLeader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
             LocalDate startDate = LocalDate.of(2025, 1, 1);
             LocalDate endDate = LocalDate.of(2025, 1, 2);
-            Team team = createTeamWithId("team", createMemberWithId("leader"), startDate, endDate);
+            Team team = createTeamWithId("team", createMemberWithId("leader"), startDate, endDate, LocalDate.now(clock));
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("hoho", startDate, endDate, FeedbackType.ANONYMOUS);
 
             when(memberRepository.findById(notLeader.getId())).thenReturn(Optional.of(notLeader));
@@ -456,10 +462,12 @@ class TeamServiceTest {
         void updateTeamInfo_기간초과1(){
             // given
             Member leader = createMemberWithId("leader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
             LocalDate startDate = LocalDate.of(2025, 1, 1);
             LocalDate endDate = LocalDate.of(2025, 1, 3);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
-            Team team = createTeamWithId("team", leader, startDate, endDate);
+            Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
             when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
@@ -476,10 +484,12 @@ class TeamServiceTest {
         void updateTeamInfo_기간초과2(){
             // given
             Member leader = createMemberWithId("leader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
             LocalDate startDate = LocalDate.of(2025, 1, 2);
             LocalDate endDate = LocalDate.of(2025, 1, 3);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
-            Team team = createTeamWithId("team", leader, startDate, endDate);
+            Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
             when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));

--- a/back-end/src/test/java/com/feedhanjum/back_end/test/util/DomainTestUtils.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/test/util/DomainTestUtils.java
@@ -27,21 +27,21 @@ public class DomainTestUtils {
     }
 
     public static Team createTeamWithoutId(String name, Member leader) {
-        return createTeamWithoutId(name, leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
+        return createTeamWithoutId(name, leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), LocalDate.now());
     }
 
-    public static Team createTeamWithoutId(String name, Member leader, LocalDate startDate, LocalDate endDate) {
-        return new Team(name, leader, startDate, endDate, FeedbackType.ANONYMOUS);
+    public static Team createTeamWithoutId(String name, Member leader, LocalDate startDate, LocalDate endDate, LocalDate now) {
+        return new Team(name, leader, startDate, endDate, FeedbackType.ANONYMOUS, now);
     }
 
-    public static Team createTeamWithId(String name, Member leader, LocalDate startDate, LocalDate endDate) {
+    public static Team createTeamWithId(String name, Member leader, LocalDate startDate, LocalDate endDate, LocalDate now) {
         Long id = nextId.getAndIncrement();
-        Team team = createTeamWithoutId(name, leader, startDate, endDate);
+        Team team = createTeamWithoutId(name, leader, startDate, endDate, now);
         ReflectionTestUtils.setField(team, "id", id);
         return team;
     }
 
     public static Team createTeamWithId(String name, Member leader) {
-        return createTeamWithId(name, leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1));
+        return createTeamWithId(name, leader, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1), LocalDate.now());
     }
 }


### PR DESCRIPTION
# 관련 이슈
FD-333

# 변경된 점
- [x] 팀 스페이스 종료 날짜가 현재보다 미래인지 검증하는 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced schedule management that now notifies connected components when a new schedule is created.
  - Improved team management with stricter timeline validation to prevent past end dates and automatic notifications for leadership changes.

- **Refactor**
  - Streamlined notification handling by updating the notification framework to support future extensibility.
  - Unified date handling across team processes to ensure consistency and accuracy in scheduling and validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->