### PR TITLE
[FD-307] 팀스페이스 관리 api 연결

### DIFF
--- a/front-end/src/api/useCalendar.js
+++ b/front-end/src/api/useCalendar.js
@@ -48,9 +48,7 @@ export const usePostSchedule = (teamId) => {
   return useMutation({
     mutationFn: (data) =>
       api.post({ url: `/api/team/${teamId}/schedule/create`, body: data }),
-    onSuccess: (data) => {
-      console.log(data);
-      console.log('성공 테스트1');
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['schedules'] });
     },
   });

--- a/front-end/src/api/useTeamspace.js
+++ b/front-end/src/api/useTeamspace.js
@@ -1,5 +1,6 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from './baseApi';
+import { showToast } from '../utility/handleToast';
 
 export const useMembers = (teamId) => {
   return useQuery({
@@ -16,12 +17,14 @@ export const useTeamInfo = (teamId) => {
 };
 
 export const useSetLeader = (teamId) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (leaderId) => {
-      const sendingData = {
-        newLeaderId: leaderId,
-      };
-      return api.post({ url: `/api/team/${teamId}/leader`, body: sendingData });
+      return api.post({ url: `/api/team/${teamId}/leader`, body: leaderId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['team', teamId]);
+      showToast('팀장이 바뀌었어요');
     },
   });
 };

--- a/front-end/src/api/useTeamspace.js
+++ b/front-end/src/api/useTeamspace.js
@@ -30,9 +30,14 @@ export const useSetLeader = (teamId) => {
 };
 
 export const useKickMember = (teamId) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (memberId) => {
       return api.delete({ url: `/api/team/${teamId}/member/${memberId}` });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['team', teamId]);
+      showToast('팀원을 내보냈어요');
     },
   });
 };

--- a/front-end/src/api/useTeamspace.js
+++ b/front-end/src/api/useTeamspace.js
@@ -55,10 +55,14 @@ export const useMakeTeam = () => {
 };
 
 export const useEditTeam = (teamId) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (teamInfo) => {
       const sendingData = teamInfo;
-      return api.post({ url: `/api/team/${teamId}/`, body: sendingData });
+      return api.post({ url: `/api/team/${teamId}`, body: sendingData });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['team', teamId]);
     },
   });
 };

--- a/front-end/src/api/useTeamspace.js
+++ b/front-end/src/api/useTeamspace.js
@@ -67,10 +67,14 @@ export const useEditTeam = (teamId) => {
   });
 };
 
-export const useDeleteTeam = (teamId) => {
+export const useLeaveTeam = (teamId) => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => {
       return api.delete({ url: `/api/team/${teamId}/leave` });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['team', teamId]);
     },
   });
 };

--- a/front-end/src/components/MainCard2.jsx
+++ b/front-end/src/components/MainCard2.jsx
@@ -21,8 +21,8 @@ export default function MainCard2({ teamMates, onClick }) {
             <ProfileImageWithText
               key={index}
               text={mate.name}
-              iconName={`@animals/${mate.iconName}`}
-              color={mate.color}
+              iconName={`@animals/${mate.profileImage.image}`}
+              color={mate.profileImage.backgroundColor}
               onClick={() => onClick(mate)}
             />
           );

--- a/front-end/src/mocks/handlers.js
+++ b/front-end/src/mocks/handlers.js
@@ -24,9 +24,9 @@ export const handlers = [
   }),
 
   // 팀 멤버 조회
-  http.get(`${BASE_URL}/api/team/:teamId/members`, () => {
-    return HttpResponse.json(members);
-  }),
+  // http.get(`${BASE_URL}/api/team/:teamId/members`, () => {
+  //   return HttpResponse.json(members);
+  // }),
 
   // 알람 조회
   http.get(`${BASE_URL}/api/notification`, () => {

--- a/front-end/src/mocks/handlers2.js
+++ b/front-end/src/mocks/handlers2.js
@@ -72,9 +72,9 @@ export const handlers2 = [
   ),
 
   // 리더 변경
-  http.post(`${BASE_URL}/api/team/:teamId/leader`, () => {
-    return new HttpResponse({ status: 200 });
-  }),
+  // http.post(`${BASE_URL}/api/team/:teamId/leader`, () => {
+  //   return new HttpResponse({ status: 200 });
+  // }),
 
   // 멤버 삭제
   http.delete(`${BASE_URL}/api/team/:teamId/member/:memberId`, () => {

--- a/front-end/src/mocks/handlers2.js
+++ b/front-end/src/mocks/handlers2.js
@@ -87,7 +87,7 @@ export const handlers2 = [
   // }),
 
   // 팀 삭제
-  http.delete(`${BASE_URL}/api/team/:teamId/leave`, () => {
-    return HttpResponse.json(teamResponse);
-  }),
+  // http.delete(`${BASE_URL}/api/team/:teamId/leave`, () => {
+  //   return HttpResponse.json(teamResponse);
+  // }),
 ];

--- a/front-end/src/mocks/handlers2.js
+++ b/front-end/src/mocks/handlers2.js
@@ -41,9 +41,9 @@ export const handlers2 = [
   }),
 
   // 팀 멤버 조회
-  http.get(`${BASE_URL}/api/team/:teamId/members`, () => {
-    return HttpResponse.json(members2);
-  }),
+  // http.get(`${BASE_URL}/api/team/:teamId/members`, () => {
+  //   return HttpResponse.json(members2);
+  // }),
 
   // 피드백 받은 내역 조회
   // http.get(`${BASE_URL}/api/feedbacks/receiver/:memberId`, () => {

--- a/front-end/src/mocks/handlers2.js
+++ b/front-end/src/mocks/handlers2.js
@@ -77,9 +77,9 @@ export const handlers2 = [
   // }),
 
   // 멤버 삭제
-  http.delete(`${BASE_URL}/api/team/:teamId/member/:memberId`, () => {
-    return new HttpResponse({ status: 204 });
-  }),
+  // http.delete(`${BASE_URL}/api/team/:teamId/member/:memberId`, () => {
+  //   return new HttpResponse({ status: 204 });
+  // }),
 
   // 팀 수정
   // http.post(`${BASE_URL}/api/team/:teamId`, () => {

--- a/front-end/src/mocks/mockData.js
+++ b/front-end/src/mocks/mockData.js
@@ -107,25 +107,25 @@ export const members = [
   {
     id: 1,
     name: '백현식',
-    iconName: 'panda',
+    iconName: 'Panda',
     color: '#90C18A',
   },
   {
     id: 2,
     name: '양준호',
-    iconName: 'penguin',
+    iconName: 'Penguin',
     color: '#AFD1DC',
   },
   {
     id: 3,
     name: '김민수',
-    iconName: 'whale',
+    iconName: 'Whale',
     color: '#F28796',
   },
   {
     id: 4,
     name: '한준호',
-    iconName: 'rooster',
+    iconName: 'Rooster',
     color: '#62BFCA',
   },
 ];

--- a/front-end/src/pages/feedback/components/FeedBack.jsx
+++ b/front-end/src/pages/feedback/components/FeedBack.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import Icon from '../../../components/Icon';
-import ProfileImage from '../../../components/ProfileImage';
+import ProfileImage, {
+  getRandomProfile,
+} from '../../../components/ProfileImage';
 import Tag from '../../../components/Tag';
 import {
   useFeedbackLikeCancel,
@@ -35,14 +37,20 @@ export default function FeedBack({ feedbackType, data }) {
     <div className='flex flex-col gap-5 border-b-8 border-gray-800 bg-gray-900 py-5'>
       <div className='flex gap-3'>
         {/* 회고 아닌 경우에만 프로필 이미지 표시 */}
-        {FeedBackType[feedbackType] !== FeedBackType.SELF && (
-          <div className='aspect-square h-11'>
-            <ProfileImage
-              iconName={'@animals/' + teamMate.image}
-              color={teamMate.backgroundColor}
-            />
-          </div>
-        )}
+        {FeedBackType[feedbackType] !== FeedBackType.SELF &&
+          (teamMate ?
+            <div className='aspect-square h-11'>
+              <ProfileImage
+                iconName={'@animals/' + teamMate.image}
+                color={teamMate.backgroundColor}
+              />
+            </div>
+          : <div className='aspect-square h-11'>
+              <ProfileImage
+                iconName={'@animals/' + getRandomProfile().image}
+                color={getRandomProfile().backgroundColor}
+              />
+            </div>)}
         <div className='flex flex-1 flex-col gap-0.5'>
           {/* 회고 아닌 경우 To. 또는 From. + 이름 표시 || 회고인 경우 팀 이름 표시 */}
           <p className='body-3 text-gray-0'>

--- a/front-end/src/pages/teamspace/TeamSpaceEdit.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceEdit.jsx
@@ -13,7 +13,7 @@ import CustomDatePicker, {
 import Modal from '../../components/modals/Modal';
 import MediumButton from '../../components/buttons/MediumButton';
 import { hideModal, showModal } from '../../utility/handleModal';
-import { useDeleteTeam, useEditTeam } from '../../api/useTeamspace';
+import { useEditTeam, useLeaveTeam } from '../../api/useTeamspace';
 
 /**
  * @param {object} props
@@ -31,10 +31,19 @@ export default function TeamSpaceEdit({ isFirst = false }) {
   });
   const [isDatePickerOpen1, setIsDatePickerOpen1] = useState(false);
   const [isDatePickerOpen2, setIsDatePickerOpen2] = useState(false);
+  const [canDelete, setCanDelete] = useState(false);
   const { mutate: editTeam } = useEditTeam(teamId);
-  const { mutate: deleteTeam } = useDeleteTeam(teamId);
+  const { mutate: leaveTeam } = useLeaveTeam(teamId);
 
   const navigate = useNavigate();
+
+  const handleDeleteButton = () => {
+    if (canDelete) {
+      showModal(deleteTeamModal);
+    } else {
+      showToast('남은 팀원이 있어 삭제할 수 없어요');
+    }
+  };
 
   const deleteTeamModal = (
     <Modal
@@ -45,9 +54,12 @@ export default function TeamSpaceEdit({ isFirst = false }) {
           text='삭제'
           isOutlined={false}
           onClick={() => {
-            deleteTeam();
-            hideModal();
-            navigate('/teamspace/list');
+            leaveTeam(null, {
+              onSuccess: () => {
+                hideModal();
+                navigate('/teamspace/list');
+              },
+            });
           }}
         />
       }
@@ -79,8 +91,8 @@ export default function TeamSpaceEdit({ isFirst = false }) {
 
   useEffect(() => {
     if (location.state) {
-      console.log(location.state?.teamResponse);
       setTeam(location.state?.teamResponse);
+      setCanDelete(location.state?.members?.length < 2);
     }
   }, []);
 
@@ -189,7 +201,7 @@ export default function TeamSpaceEdit({ isFirst = false }) {
             'rounded-300 flex h-[56px] w-full items-center justify-center px-4 py-2 text-gray-300'
           }
         >
-          <a onClick={() => showModal(deleteTeamModal)}>팀 스페이스 삭제</a>
+          <a onClick={() => handleDeleteButton()}>팀 스페이스 삭제</a>
         </div>
       </div>
     </div>

--- a/front-end/src/pages/teamspace/TeamSpaceEdit.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceEdit.jsx
@@ -27,7 +27,7 @@ export default function TeamSpaceEdit({ isFirst = false }) {
     name: '',
     startDate: new Date(),
     endDate: new Date(),
-    feedbackType: false,
+    feedbackType: 'ANONYMOUS',
   });
   const [isDatePickerOpen1, setIsDatePickerOpen1] = useState(false);
   const [isDatePickerOpen2, setIsDatePickerOpen2] = useState(false);
@@ -69,8 +69,8 @@ export default function TeamSpaceEdit({ isFirst = false }) {
       return;
     } else {
       editTeam(team);
+      navigate(-1);
     }
-    navigate(-1);
   };
 
   const onClickPop = () => {
@@ -79,6 +79,7 @@ export default function TeamSpaceEdit({ isFirst = false }) {
 
   useEffect(() => {
     if (location.state) {
+      console.log(location.state?.teamResponse);
       setTeam(location.state?.teamResponse);
     }
   }, []);
@@ -148,11 +149,24 @@ export default function TeamSpaceEdit({ isFirst = false }) {
         addOn={
           <button
             className='flex h-full w-full items-center justify-center'
-            onClick={() =>
-              setTeam({ ...team, feedbackType: !team.feedbackType })
-            }
+            onClick={() => {
+              console.log(team.feedbackType);
+              setTeam({
+                ...team,
+                feedbackType:
+                  team.feedbackType === 'IDENTIFIED' ?
+                    'ANONYMOUS'
+                  : 'IDENTIFIED',
+              });
+            }}
           >
-            <Icon name={team.feedbackType ? 'checkBoxClick' : 'checkBoxNone'} />
+            <Icon
+              name={
+                team.feedbackType === 'ANONYMOUS' ?
+                  'checkBoxClick'
+                : 'checkBoxNone'
+              }
+            />
           </button>
         }
       />

--- a/front-end/src/pages/teamspace/TeamSpaceList.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceList.jsx
@@ -16,7 +16,7 @@ export default function TeamSpaceList() {
   }
 
   return (
-    <div className='flex flex-col'>
+    <div className='scrollbar-hidden flex h-full flex-col overflow-x-hidden overflow-y-auto'>
       <StickyWrapper>
         <NavBar2
           canPop={true}
@@ -35,9 +35,9 @@ export default function TeamSpaceList() {
           <p className={`${showEndedTeams ? 'text-lime-500' : ''}`}>종료됨</p>
         </button>
       </div>
-      <ul className='flex flex-col gap-4'>
-        {teams &&
-          teams
+      {teams.length > 0 ?
+        <ul className='flex flex-col gap-4'>
+          {teams
             .filter((team) => {
               if (showEndedTeams) {
                 return checkIsFinished(team.endDate);
@@ -59,7 +59,12 @@ export default function TeamSpaceList() {
                 />
               </button>
             ))}
-      </ul>
+        </ul>
+      : <div className='flex h-full flex-col items-center justify-center gap-4 text-gray-300'>
+          <p className='text-5xl'>😢</p>
+          <p>소속된 팀이 없어요</p>
+        </div>
+      }
     </div>
   );
 }

--- a/front-end/src/pages/teamspace/TeamSpaceManage.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceManage.jsx
@@ -21,6 +21,8 @@ export default function TeamSpaceManage() {
     if (team) {
       if (team?.teamResponse?.leader?.id == userId) {
         setIamLeader(true);
+      } else {
+        setIamLeader(false);
       }
     }
   }, [team]);

--- a/front-end/src/pages/teamspace/TeamSpaceManage.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceManage.jsx
@@ -2,22 +2,24 @@ import { useNavigate, useParams } from 'react-router-dom';
 import NavBar2 from '../../components/NavBar2';
 import Tag, { TagType } from '../../components/Tag';
 import StickyWrapper from '../../components/wrappers/StickyWrapper';
-import { useTeamInfo } from '../../api/useTeamspace';
+import { useInviteTeam, useTeamInfo } from '../../api/useTeamspace';
 import { useEffect, useState } from 'react';
 import Icon from '../../components/Icon';
 import MemberElement from './components/MemberElement';
 import { showToast } from '../../utility/handleToast';
+import { useUser } from '../../useUser';
 
 export default function TeamSpaceManage() {
   const { teamId } = useParams();
   const [iamLeader, setIamLeader] = useState(false);
   const { data: team } = useTeamInfo(teamId);
+  const { userId } = useUser();
   const navigate = useNavigate();
+  const { mutate: inviteTeam } = useInviteTeam();
 
   useEffect(() => {
     if (team) {
-      // TODO: id를 본인 것과 비교
-      if (team?.teamResponse?.leader?.id === 52345513) {
+      if (team?.teamResponse?.leader?.id == userId) {
         setIamLeader(true);
       }
     }
@@ -51,10 +53,13 @@ export default function TeamSpaceManage() {
         </div>
         <button
           onClick={() => {
-            navigator.clipboard.writeText(
-              `${window.location.origin}/teamspace/${teamId}`,
-            );
-            showToast('초대링크 복사 완료');
+            inviteTeam(teamId, {
+              onSuccess: (data) => {
+                const inviteCode = data.token;
+                navigator.clipboard.writeText(`feedhanjum.com/${inviteCode}`);
+                showToast('초대링크 복사 완료');
+              },
+            });
           }}
         >
           <Tag type={TagType.TEAM_NAME}>초대링크 복사</Tag>

--- a/front-end/src/pages/teamspace/components/MemberElement.jsx
+++ b/front-end/src/pages/teamspace/components/MemberElement.jsx
@@ -70,13 +70,15 @@ export default function MemberElement({ teamId, member, leaderId, iamLeader }) {
       <div className='flex flex-1 flex-col gap-2'>
         <div className='flex items-center gap-3'>
           <p className='subtitle-1 text-gray-100'>{member.name}</p>
-          {member.id === leaderId ?
+          {member.id == leaderId ?
             <Tag type={TagType.TEAM_LEADER} />
           : null}
         </div>
-        <p className='caption-1 text-gray-300'>{member.email}</p>
+        <p className='caption-1 overflow-ellipsis text-gray-300'>
+          {member.email}
+        </p>
       </div>
-      {iamLeader && member.id !== leaderId ?
+      {iamLeader && member.id != leaderId ?
         <div className='flex gap-2'>
           <div
             className='flex h-9 w-9 cursor-pointer items-center justify-center rounded-full bg-gray-600 p-1.5'

--- a/front-end/src/pages/teamspace/components/MemberElement.jsx
+++ b/front-end/src/pages/teamspace/components/MemberElement.jsx
@@ -1,10 +1,15 @@
-import { useKickMember, useSetLeader } from '../../../api/useTeamspace';
+import {
+  useKickMember,
+  useLeaveTeam,
+  useSetLeader,
+} from '../../../api/useTeamspace';
 import MediumButton from '../../../components/buttons/MediumButton';
 import Icon from '../../../components/Icon';
 import Modal from '../../../components/modals/Modal';
 import ProfileImage from '../../../components/ProfileImage';
 import Tag, { TagType } from '../../../components/Tag';
 import { hideModal, showModal } from '../../../utility/handleModal';
+import { useNavigate } from 'react-router-dom';
 
 /**
  * 팀원 요소 컴포넌트
@@ -19,6 +24,8 @@ import { hideModal, showModal } from '../../../utility/handleModal';
 export default function MemberElement({ teamId, member, leaderId, iamLeader }) {
   const { mutate: setLeader } = useSetLeader(teamId);
   const { mutate: kickMember } = useKickMember(teamId);
+  const { mutate: leaveTeam } = useLeaveTeam(teamId);
+  const navigate = useNavigate();
 
   const changeLeaderModal = (
     <Modal
@@ -48,6 +55,27 @@ export default function MemberElement({ teamId, member, leaderId, iamLeader }) {
           onClick={() => {
             kickMember(member.id);
             hideModal();
+          }}
+        />
+      }
+    />
+  );
+
+  const leaveTeamModal = (
+    <Modal
+      type='SINGLE'
+      content={`정말 팀에서 떠나시겠어요?`}
+      mainButton={
+        <MediumButton
+          text='확인'
+          isOutlined={false}
+          onClick={() => {
+            leaveTeam(null, {
+              onSuccess: () => {
+                hideModal();
+                navigate('/teamspace/list');
+              },
+            });
           }}
         />
       }
@@ -96,6 +124,15 @@ export default function MemberElement({ teamId, member, leaderId, iamLeader }) {
           >
             <Icon name={'logout'} color={'var(--color-gray-200)'} />
           </div>
+        </div>
+      : !iamLeader && member.id != leaderId ?
+        <div
+          className='flex h-9 w-9 cursor-pointer items-center justify-center rounded-full bg-gray-600 p-1.5'
+          onClick={() => {
+            showModal(leaveTeamModal);
+          }} // 떠나기
+        >
+          <Icon name={'logout'} color={'var(--color-gray-200)'} />
         </div>
       : null}
     </li>

--- a/front-end/src/pages/teamspace/components/TeamElement.jsx
+++ b/front-end/src/pages/teamspace/components/TeamElement.jsx
@@ -66,8 +66,8 @@ export default function TeamElement({
                   </div>
                 : <div className='h-8 w-8'>
                     <ProfileImage
-                      iconName={`@animals/${member.iconName}`}
-                      color={member.color}
+                      iconName={`@animals/${member.profileImage.image}`}
+                      color={member.profileImage.backgroundColor}
                     />
                   </div>
                 }


### PR DESCRIPTION
팀스페이스 관련 API 연결 완료했습니다
- 팀 목록 조회
- 팀 멤버 조회
- 팀 상세 조회
- 팀 리더 변경
- 팀 멤버 내보내기 (팀장만 가능)
- 팀 나가기 (팀장이 아닌 사람 중 본인만 가능)
- 팀 삭제 (팀장만, 혼자 남았을 때 가능)
- 팀 정보 수정 (팀장만 가능)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced team management actions with real-time notifications and confirmation modals, providing clearer feedback during leader changes, member removals, and invitations.
  - Introduced a fallback mechanism for profile images in feedback, ensuring a consistent display.

- **Refactor**
  - Improved the visual presentation of team listings and member profiles, with conditional messaging when no teams are available and updated profile image rendering for a more unified UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->