### PR TITLE
[FD-339]  order by를 적용한 쿼리가 fetch one을 사용한 문제 해결

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/controller/MemberController.java
@@ -62,9 +62,9 @@ public class MemberController {
             @ApiResponse(responseCode = "404", description = "해당 회원이 존재하지 않을 경우", content = @Content)
     })
     @PostMapping("/member")
-    public ResponseEntity<MemberDto> changeProfile(@Login Long memberId, @Valid @RequestBody ProfileChangeRequest profileChageRequest) {
-        String name = profileChageRequest.name();
-        ProfileImage profileImage = profileChageRequest.profileImage();
+    public ResponseEntity<MemberDto> changeProfile(@Login Long memberId, @Valid @RequestBody ProfileChangeRequest profileChangeRequest) {
+        String name = profileChangeRequest.name();
+        ProfileImage profileImage = profileChangeRequest.profileImage();
         MemberDto memberDto = new MemberDto(memberService.changeProfile(memberId, name, profileImage));
         return new ResponseEntity<>(memberDto, HttpStatus.OK);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleQueryRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/ScheduleQueryRepository.java
@@ -37,7 +37,7 @@ public class ScheduleQueryRepository {
                 .from(schedule)
                 .where(schedule.team.id.eq(teamId), schedule.startTime.after(time))
                 .orderBy(schedule.startTime.asc())
-                .fetchOne();
+                .fetchFirst();
 
         if(closestNextScheduleId == null) return List.of();
 
@@ -51,7 +51,7 @@ public class ScheduleQueryRepository {
                 .from(schedule)
                 .where(schedule.team.id.eq(teamId), schedule.endTime.before(time))
                 .orderBy(schedule.endTime.desc())
-                .fetchOne();
+                .fetchFirst();
 
         if(closestPreviousSchedule == null) return List.of();
 
@@ -78,7 +78,7 @@ public class ScheduleQueryRepository {
                 .from(schedule)
                 .where(teamIdEq(teamId))
                 .orderBy(schedule.startTime.asc())
-                .fetchOne());
+                .fetchFirst());
     }
 
     public Optional<LocalDateTime> findLatestEndTimeByTeamId(Long teamId){
@@ -86,7 +86,7 @@ public class ScheduleQueryRepository {
                 .from(schedule)
                 .where(teamIdEq(teamId))
                 .orderBy(schedule.endTime.desc())
-                .fetchOne());
+                .fetchFirst());
     }
 
 


### PR DESCRIPTION
# 관련 이슈
FD-339

# 변경된 점
- [x] order by를 적용한 쿼리가 fetch one 을 사용한 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a minor issue with member profile updates for improved consistency.
	- Enhanced schedule data retrieval to handle cases with missing information more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->