### PR TITLE
[FD-335] 피드백 팀 객관식 피드백 value object로 리팩터링

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/AssociatedTeam.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/AssociatedTeam.java
@@ -1,0 +1,20 @@
+package com.feedhanjum.back_end.feedback.domain;
+
+import com.feedhanjum.back_end.team.domain.Team;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@EqualsAndHashCode
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class AssociatedTeam {
+    private Long id;
+
+    private String name;
+
+    public static AssociatedTeam of(Team team) {
+        return new AssociatedTeam(team.getId(), team.getName());
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -43,7 +45,6 @@ public class Feedback {
     @AttributeOverrides({
             @AttributeOverride(name = "id", column = @Column(name = "sender_id")),
             @AttributeOverride(name = "name", column = @Column(name = "sender_name")),
-            @AttributeOverride(name = "profileImage", column = @Column(name = "sender_profile_image")),
     })
     private Sender sender;
 
@@ -51,7 +52,6 @@ public class Feedback {
     @AttributeOverrides({
             @AttributeOverride(name = "id", column = @Column(name = "receiver_id")),
             @AttributeOverride(name = "name", column = @Column(name = "receiver_name")),
-            @AttributeOverride(name = "profileImage", column = @Column(name = "receiver_profile_image")),
     })
     private Receiver receiver;
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
@@ -63,8 +63,8 @@ public class Feedback {
     private AssociatedTeam team;
 
     // 객관식 피드백
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "objective_feedback", joinColumns = @JoinColumn(name = "feedback_id"))
+    @Column(name = "objectiveFeedbacks", columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
     private final Set<ObjectiveFeedback> objectiveFeedbacks = new HashSet<>();
 
     /**

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Feedback.java
@@ -55,9 +55,12 @@ public class Feedback {
     })
     private Receiver receiver;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id")
-    private Team team;
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "id", column = @Column(name = "team_id")),
+            @AttributeOverride(name = "name", column = @Column(name = "team_name")),
+    })
+    private AssociatedTeam team;
 
     // 객관식 피드백
     @ElementCollection(fetch = FetchType.LAZY)
@@ -75,7 +78,7 @@ public class Feedback {
         this.objectiveFeedbacks.addAll(objectiveFeedbacks);
         this.sender = Sender.of(sender);
         this.receiver = Receiver.of(receiver);
-        this.team = team;
+        this.team = AssociatedTeam.of(team);
         this.createdAt = LocalDateTime.now();
         validateObjectiveFeedbacks();
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Sender.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/Sender.java
@@ -3,8 +3,7 @@ package com.feedhanjum.back_end.feedback.domain;
 
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.Embedded;
+import jakarta.persistence.*;
 import lombok.*;
 
 @EqualsAndHashCode
@@ -18,6 +17,10 @@ public class Sender {
     private String name;
 
     @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "backgroundColor", column = @Column(name = "sender_background_color")),
+            @AttributeOverride(name = "image", column = @Column(name = "sender_image"))
+    })
     private ProfileImage profileImage;
 
     public static Sender of(Member sender) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -216,7 +216,8 @@ public class FeedbackService {
                 .orElseThrow();
         Member sender = memberRepository.findById(feedback.getSender().getId())
                 .orElseThrow();
-        Team team = feedback.getTeam();
+        Team team = teamRepository.findById(feedback.getTeam().getId())
+                .orElseThrow();
 
         team.removeFeedbackRequest(sender, receiver);
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/member/domain/Member.java
@@ -4,7 +4,8 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.util.HashSet;
 import java.util.List;
@@ -25,11 +26,8 @@ public class Member {
     @Embedded
     private ProfileImage profileImage;
 
-    @ElementCollection(targetClass = FeedbackPreference.class, fetch = FetchType.EAGER)
-    @Enumerated(EnumType.STRING)
-    @CollectionTable(name = "feedback_preference", joinColumns = @JoinColumn(name = "member_id"))
-    @Column(name = "feedback_preference")
-    @BatchSize(size = 16)
+    @Column(name = "feedback_preference", columnDefinition = "json")
+    @JdbcTypeCode(SqlTypes.JSON)
     private Set<FeedbackPreference> feedbackPreferences = new HashSet<>();
 
     public Member(String name, String email, ProfileImage profileImage, List<FeedbackPreference> feedbackPreferences) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/FeedbackControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/controller/FeedbackControllerTest.java
@@ -49,8 +49,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 
-import static com.feedhanjum.back_end.test.util.DomainTestUtils.assertEqualReceiver;
-import static com.feedhanjum.back_end.test.util.DomainTestUtils.assertEqualSender;
+import static com.feedhanjum.back_end.test.util.DomainTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
@@ -200,7 +199,7 @@ class FeedbackControllerTest {
             Feedback feedback = feedbacks.get(0);
             assertEqualSender(sender, feedback.getSender());
             assertEqualReceiver(receiver, feedback.getReceiver());
-            assertThat(feedback.getTeam()).isEqualTo(team);
+            assertEqualTeam(team, feedback.getTeam());
             assertThat(feedback.getFeedbackType()).isEqualTo(FeedbackType.ANONYMOUS);
             assertThat(feedback.getFeedbackFeeling()).isEqualTo(FeedbackFeeling.CONSTRUCTIVE);
             assertThat(feedback.getObjectiveFeedbacks()).containsExactlyInAnyOrderElementsOf(FeedbackFeeling.CONSTRUCTIVE.getObjectiveFeedbacks().subList(1, 3));
@@ -271,13 +270,12 @@ class FeedbackControllerTest {
                     .content(mapper.writeValueAsString(request))
             ).hasStatus(HttpStatus.NO_CONTENT);
 
-
             List<Feedback> feedbacks = feedbackRepository.findAll();
             assertThat(feedbacks).hasSize(1);
             Feedback feedback = feedbacks.get(0);
             assertEqualSender(sender, feedback.getSender());
             assertEqualReceiver(receiver, feedback.getReceiver());
-            assertThat(feedback.getTeam()).isEqualTo(team);
+            assertEqualTeam(team, feedback.getTeam());
             assertThat(feedback.getFeedbackType()).isEqualTo(FeedbackType.ANONYMOUS);
             assertThat(feedback.getFeedbackFeeling()).isEqualTo(FeedbackFeeling.CONSTRUCTIVE);
             assertThat(feedback.getObjectiveFeedbacks()).containsExactlyInAnyOrderElementsOf(FeedbackFeeling.CONSTRUCTIVE.getObjectiveFeedbacks().subList(1, 3));

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -140,7 +140,7 @@ class FeedbackServiceTest {
             // then
             assertEqualSender(sender, feedback.getSender());
             assertEqualReceiver(receiver, feedback.getReceiver());
-            assertThat(feedback.getTeam()).isEqualTo(team);
+            assertEqualTeam(team, feedback.getTeam());
             assertThat(feedback.getFeedbackType()).isEqualTo(feedbackType);
             assertThat(feedback.getFeedbackFeeling()).isEqualTo(feedbackFeeling);
             assertThat(feedback.getObjectiveFeedbacks())
@@ -451,7 +451,7 @@ class FeedbackServiceTest {
             // then
             assertEqualSender(sender, feedback.getSender());
             assertEqualReceiver(receiver, feedback.getReceiver());
-            assertThat(feedback.getTeam()).isEqualTo(team);
+            assertEqualTeam(team, feedback.getTeam());
             assertThat(feedback.getFeedbackType()).isEqualTo(feedbackType);
             assertThat(feedback.getFeedbackFeeling()).isEqualTo(feedbackFeeling);
             assertThat(feedback.getObjectiveFeedbacks())
@@ -927,7 +927,7 @@ class FeedbackServiceTest {
             when(feedbackRepository.findById(feedback.getId())).thenReturn(Optional.of(feedback));
             when(memberRepository.findById(sender.getId())).thenReturn(Optional.of(sender));
             when(memberRepository.findById(receiver.getId())).thenReturn(Optional.of(receiver));
-
+            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
 
             // when
             feedbackService.deleteRelatedFrequentFeedbackRequest(feedback.getId());
@@ -964,6 +964,7 @@ class FeedbackServiceTest {
             when(feedbackRepository.findById(feedback.getId())).thenReturn(Optional.of(feedback));
             when(memberRepository.findById(receiver.getId())).thenReturn(Optional.of(receiver));
             when(memberRepository.findById(sender.getId())).thenReturn(Optional.of(sender));
+            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
 
 
             // when & then

--- a/back-end/src/test/java/com/feedhanjum/back_end/test/util/DomainTestUtils.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/test/util/DomainTestUtils.java
@@ -1,5 +1,6 @@
 package com.feedhanjum.back_end.test.util;
 
+import com.feedhanjum.back_end.feedback.domain.AssociatedTeam;
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.feedback.domain.Receiver;
 import com.feedhanjum.back_end.feedback.domain.Sender;
@@ -76,5 +77,10 @@ public class DomainTestUtils {
         assertThat(member.getId()).isEqualTo(receiver.getId());
         assertThat(member.getName()).isEqualTo(receiver.getName());
         assertThat(member.getProfileImage()).isEqualTo(receiver.getProfileImage());
+    }
+
+    public static void assertEqualTeam(Team team, AssociatedTeam associatedTeam) {
+        assertThat(team.getId()).isEqualTo(associatedTeam.getId());
+        assertThat(team.getName()).isEqualTo(associatedTeam.getName());
     }
 }


### PR DESCRIPTION
# 관련 이슈
FD-335

# 변경된 점
- Feedback의 team을 기존의 Team 엔티티에서 Value Object로 리팩터링
- Member의 feedbackPreferences, Feedback의 objectiveFeedbacks 를 별도 테이블이 아닌 같은 테이블의 Json타입으로 임베딩