### PR TITLE
[FD-338] 익명 피드백 도착 알림에서 보낸사람 이름을 익명처리

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/FeedbackType.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/domain/FeedbackType.java
@@ -1,5 +1,9 @@
 package com.feedhanjum.back_end.feedback.domain;
 
 public enum FeedbackType {
-    ANONYMOUS, IDENTIFIED
+    ANONYMOUS, IDENTIFIED;
+
+    public boolean isAnonymous() {
+        return this == ANONYMOUS;
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReceiveNotificationDto.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/controller/dto/notification/FeedbackReceiveNotificationDto.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public class FeedbackReceiveNotificationDto extends InAppNotificationDto {
     @Schema(description = "알림 타입", allowableValues = NotificationType.FEEDBACK_RECEIVE)
     private final String type = NotificationType.FEEDBACK_RECEIVE;
-    @Schema(description = "보낸 사람 이름")
+    @Schema(description = "보낸 사람 이름. 익명 피드백의 경우 '익명'")
     private final String senderName;
     @Schema(description = "팀 이름")
     private final String teamName;

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReceiveNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FeedbackReceiveNotification.java
@@ -13,13 +13,17 @@ import lombok.NoArgsConstructor;
 @Entity
 @DiscriminatorValue(NotificationType.FEEDBACK_RECEIVE)
 public class FeedbackReceiveNotification extends InAppNotification {
+    private static final String ANONYMOUS_SENDER_NAME = "익명";
     private String senderName;
     private String teamName;
     private Long teamId;
 
     public FeedbackReceiveNotification(Feedback receivedFeedback) {
         super(receivedFeedback.getReceiver().getId());
-        this.senderName = receivedFeedback.getSender().getName();
+        if (receivedFeedback.getFeedbackType().isAnonymous())
+            this.senderName = ANONYMOUS_SENDER_NAME;
+        else
+            this.senderName = receivedFeedback.getSender().getName();
         this.teamName = receivedFeedback.getTeam().getName();
         this.teamId = receivedFeedback.getTeam().getId();
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/notification/domain/FeedbackReceiveNotificationTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/notification/domain/FeedbackReceiveNotificationTest.java
@@ -1,0 +1,47 @@
+package com.feedhanjum.back_end.notification.domain;
+
+import com.feedhanjum.back_end.feedback.domain.Feedback;
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.test.util.DomainTestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.feedhanjum.back_end.test.util.DomainTestUtils.createFeedbackWithId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeedbackReceiveNotificationTest {
+
+    @Test
+    @DisplayName("익명 피드백은 보낸사람 이름이 '익명'이어야 한다")
+    void test1() {
+        // given
+        Member sender = DomainTestUtils.createMemberWithId("sender");
+        Member receiver = DomainTestUtils.createMemberWithId("receiver");
+        Team team = DomainTestUtils.createTeamWithId("team", sender);
+        Feedback feedback = createFeedbackWithId(sender, receiver, team, FeedbackType.ANONYMOUS);
+
+        // when
+        FeedbackReceiveNotification notification = new FeedbackReceiveNotification(feedback);
+
+        //then
+        assertThat(notification.getSenderName()).isEqualTo("익명");
+    }
+
+    @Test
+    @DisplayName("실명 피드백은 보낸사람 이름이 보여야 한다")
+    void test2() {
+        // given
+        Member sender = DomainTestUtils.createMemberWithId("sender");
+        Member receiver = DomainTestUtils.createMemberWithId("receiver");
+        Team team = DomainTestUtils.createTeamWithId("team", sender);
+        Feedback feedback = createFeedbackWithId(sender, receiver, team, FeedbackType.IDENTIFIED);
+
+        // when
+        FeedbackReceiveNotification notification = new FeedbackReceiveNotification(feedback);
+
+        //then
+        assertThat(notification.getSenderName()).isEqualTo("sender");
+    }
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/test/util/DomainTestUtils.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/test/util/DomainTestUtils.java
@@ -1,9 +1,6 @@
 package com.feedhanjum.back_end.test.util;
 
-import com.feedhanjum.back_end.feedback.domain.AssociatedTeam;
-import com.feedhanjum.back_end.feedback.domain.FeedbackType;
-import com.feedhanjum.back_end.feedback.domain.Receiver;
-import com.feedhanjum.back_end.feedback.domain.Sender;
+import com.feedhanjum.back_end.feedback.domain.*;
 import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
@@ -64,6 +61,12 @@ public class DomainTestUtils {
         RegularFeedbackRequest request = new RegularFeedbackRequest(LocalDateTime.of(2022, 1, 1, 0, 0), receiver, sender);
         ReflectionTestUtils.setField(request, "id", nextId.getAndIncrement());
         return request;
+    }
+
+    public static Feedback createFeedbackWithId(Member sender, Member receiver, Team team, FeedbackType feedbackType) {
+        Feedback feedback = new Feedback(feedbackType, FeedbackFeeling.POSITIVE, FeedbackFeeling.POSITIVE.getObjectiveFeedbacks().subList(0, 3), "좋아요", sender, receiver, team);
+        ReflectionTestUtils.setField(feedback, "id", nextId.getAndIncrement());
+        return feedback;
     }
 
 


### PR DESCRIPTION
# 관련 이슈
FD-338

# 변경된 점
- 피드백 도착 알림 생성 시 연관된 피드백이 익명 피드백이면 보낸사람 이름을 '익명'으로 설정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced feedback notifications now clearly distinguish between anonymous and identified feedback. When feedback is submitted anonymously, the sender’s name displays as "익명", ensuring a consistent and more intuitive experience for users reviewing notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->