### PR TITLE
[FD-178] 스플래시 로직 구현

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -39,7 +39,7 @@ export default function App() {
         <CombinedProvider>
           <Routes>
             <Route element={<Layout />}>
-              <Route path='/' element={<Splash />} />
+              <Route path='/:teamCode?' element={<Splash />} />
               <Route path='feedback'>
                 <Route path='request' element={<FeedbackRequest />} />
                 <Route path='send' element={<FeedbackSendLayout />}>

--- a/front-end/src/api/useAuth.js
+++ b/front-end/src/api/useAuth.js
@@ -1,8 +1,9 @@
 import { api } from './baseApi';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { showToast } from '../utility/handleToast';
 import { useUser } from '../useUser';
+import { useJoinTeam } from './useTeamspace';
 
 const BASE_URL_2 = '/api/auth';
 
@@ -23,6 +24,13 @@ export const useVerifyToken = () => {
   });
 };
 
+export const useGetMember = (id) => {
+  return useQuery({
+    queryKey: ['member', id],
+    queryFn: () => api.get({ url: '/api/member', params: { id } }),
+  });
+};
+
 export const useSignUp = () => {
   return useMutation({
     mutationFn: (data) =>
@@ -31,15 +39,19 @@ export const useSignUp = () => {
   });
 };
 
-export const useLogin = () => {
+export const useLogin = (teamCode) => {
   const navigate = useNavigate();
   const { setUserId } = useUser();
+  const { mutate: joinTeam } = useJoinTeam();
   return useMutation({
     mutationFn: (data) =>
       api.post({ url: '/api/auth/email/login', body: data }),
     onSuccess: (data) => {
       const { email, message, userId } = data;
       setUserId(userId);
+      if (teamCode) {
+        joinTeam(teamCode);
+      }
       navigate('/main');
     },
     onError: (error) => {

--- a/front-end/src/api/useTeamspace.js
+++ b/front-end/src/api/useTeamspace.js
@@ -67,6 +67,20 @@ export const useEditTeam = (teamId) => {
   });
 };
 
+export const useJoinTeam = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (code) => {
+      const sendingData = { token: code };
+      return api.post({ url: `/api/team/join`, params: sendingData });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(['myTeams']);
+      showToast('새 팀에 가입했어요');
+    },
+  });
+};
+
 export const useLeaveTeam = (teamId) => {
   const queryClient = useQueryClient();
   return useMutation({

--- a/front-end/src/pages/auth/SignIn.jsx
+++ b/front-end/src/pages/auth/SignIn.jsx
@@ -5,16 +5,18 @@ import logo from '../../assets/images/logo.png';
 import Icon from '../../components/Icon';
 import { useState } from 'react';
 import { useLogin } from '../../api/useAuth';
+import { useLocation } from 'react-router-dom';
 
 /**
  * 로그인 페이지
  * @returns
  */
 export default function SignIn() {
+  const locationState = useLocation().state;
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const { mutate: login, isLoading } = useLogin();
+  const { mutate: login, isLoading } = useLogin(locationState);
 
   return (
     <div className='relative flex h-dvh w-full flex-col justify-start'>

--- a/front-end/src/pages/auth/Splash.jsx
+++ b/front-end/src/pages/auth/Splash.jsx
@@ -30,15 +30,17 @@ export default function Splash() {
   };
 
   useEffect(() => {
-    if (member) {
-      setUserId(member.id);
-      if (teamCode) {
-        joinTeam(teamCode);
+    setTimeout(() => {
+      if (member) {
+        setUserId(member.id);
+        if (teamCode) {
+          joinTeam(teamCode);
+        }
+        moveTo('/main');
+      } else {
+        setIsLoading(false);
       }
-      moveTo('/main');
-    } else {
-      setIsLoading(false);
-    }
+    }, 1500);
   }, [member]);
 
   return (

--- a/front-end/src/pages/auth/Splash.jsx
+++ b/front-end/src/pages/auth/Splash.jsx
@@ -4,30 +4,42 @@ import { useEffect, useState } from 'react';
 import logo from '../../assets/images/logo.png';
 import googleLogo from '../../assets/images/google-logo.png';
 import Icon from '../../components/Icon';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useGetMember } from '../../api/useAuth';
+import { useUser } from '../../useUser';
+import { useJoinTeam } from '../../api/useTeamspace';
 
 /**
  * 스플래시 페이지
  * @returns
  */
 export default function Splash() {
+  const { teamCode } = useParams();
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
+  const { userId, setUserId } = useUser();
+  const { data: member } = useGetMember(userId);
+  const { mutate: joinTeam } = useJoinTeam();
 
   /**
    * 버튼 클릭 핸들러
    * @param {string} path - 이동할 경로
    */
-  const handleButtonClick = (path) => {
-    navigate(path);
+  const moveTo = (path) => {
+    navigate(path, { state: teamCode });
   };
 
   useEffect(() => {
-    // TODO: 로그인 여부 확인
-    setTimeout(() => {
+    if (member) {
+      setUserId(member.id);
+      if (teamCode) {
+        joinTeam(teamCode);
+      }
+      moveTo('/main');
+    } else {
       setIsLoading(false);
-    }, 3000);
-  }, []);
+    }
+  }, [member]);
 
   return (
     <div className='flex h-full w-full items-center justify-center'>
@@ -56,7 +68,7 @@ export default function Splash() {
               {/* 이메일 로그인 */}
               <button
                 className='flex w-full items-center gap-2 rounded-full border border-[#A3A3A3] bg-white px-5'
-                onClick={() => handleButtonClick('/signup')}
+                onClick={() => moveTo('/signup')}
               >
                 <div className='ml-4'>
                   <Icon name='mail' color='#595959' />
@@ -69,7 +81,7 @@ export default function Splash() {
               <p className='caption-1 text-[#414141]'>이미 회원이신가요?</p>
               <a
                 className='caption-2 text-[#414141]'
-                onClick={() => handleButtonClick('/signin')}
+                onClick={() => moveTo('/signin')}
               >
                 로그인하기
               </a>


### PR DESCRIPTION
스플래시화면에서 처리하는 로직 추가했습니다.
- 로그인 되어 있으면 메인페이지로 이동
- 루트 디렉토리에 초대코드 붙어서 온 경우,
   - 로그인되어 있었다면 바로 팀 가입 하고 홈화면으로 이동 
   - 로그인 안되어 있었다면 로그인하고 팀 가입 후 홈화면으로 이동
   - 회원가입 안되어 있던 경우는 아직 미구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The splash screen now supports an optional team code in the URL for a tailored onboarding experience.
  - Users benefit from streamlined team integration, automatically joining a team when a valid code is provided during login.

- **Enhancements**
  - The updated authentication flow leverages navigation context for a smoother sign-in experience.
  - Faster splash screen transitions improve overall responsiveness for returning users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->