### PR TITLE
[FD-216] fix: 팀 나가기버튼 사용자 본인에게만 뜨게 수정

### DIFF
--- a/front-end/src/pages/teamspace/components/MemberElement.jsx
+++ b/front-end/src/pages/teamspace/components/MemberElement.jsx
@@ -8,6 +8,7 @@ import Icon from '../../../components/Icon';
 import Modal from '../../../components/modals/Modal';
 import ProfileImage from '../../../components/ProfileImage';
 import Tag, { TagType } from '../../../components/Tag';
+import { useUser } from '../../../useUser';
 import { hideModal, showModal } from '../../../utility/handleModal';
 import { useNavigate } from 'react-router-dom';
 
@@ -25,6 +26,7 @@ export default function MemberElement({ teamId, member, leaderId, iamLeader }) {
   const { mutate: setLeader } = useSetLeader(teamId);
   const { mutate: kickMember } = useKickMember(teamId);
   const { mutate: leaveTeam } = useLeaveTeam(teamId);
+  const { userId } = useUser();
   const navigate = useNavigate();
 
   const changeLeaderModal = (
@@ -125,7 +127,7 @@ export default function MemberElement({ teamId, member, leaderId, iamLeader }) {
             <Icon name={'logout'} color={'var(--color-gray-200)'} />
           </div>
         </div>
-      : !iamLeader && member.id != leaderId ?
+      : !iamLeader && member.id == userId ?
         <div
           className='flex h-9 w-9 cursor-pointer items-center justify-center rounded-full bg-gray-600 p-1.5'
           onClick={() => {


### PR DESCRIPTION
팀스페이스 나가기 버튼이 모든 멤버에게 다 뜨던 오류 수정했습니다.
- 본인에게만 있음

<img width="431" alt="스크린샷 2025-02-14 오전 2 15 54" src="https://github.com/user-attachments/assets/b481ce29-1024-43c7-a375-cd75b5de697a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the logic for the "Leave Team" button so that it now appears only for users eligible to self-remove, ensuring a clearer and more intuitive team interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->