### PR TITLE
[FD-179] 마이페이지 로그아웃 기능추가

### DIFF
--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -43,6 +43,7 @@ export default function App() {
               <Route path='/:teamCode?' element={<Splash />} />
               <Route path='signin' element={<SignIn />} />
               <Route path='signup' element={<SignUp />} />
+              {/* 이 아래는 로그인 해야 이용 가능 */}
               <Route element={<ProtectedRoute />}>
                 <Route path='feedback'>
                   <Route path='request' element={<FeedbackRequest />} />

--- a/front-end/src/App.jsx
+++ b/front-end/src/App.jsx
@@ -29,6 +29,7 @@ import FeedbackSendStep from './pages/feedback/FeedbackSendStep';
 import FeedbackSend from './pages/feedback/FeedbackSend';
 import FeedbackFavorite from './pages/feedback/FeedbackFavorite';
 import MyPageHome from './pages/mypage/MyPageHome';
+import ProtectedRoute from './ProtectedRoute';
 
 const queryClient = new QueryClient();
 
@@ -40,45 +41,47 @@ export default function App() {
           <Routes>
             <Route element={<Layout />}>
               <Route path='/:teamCode?' element={<Splash />} />
-              <Route path='feedback'>
-                <Route path='request' element={<FeedbackRequest />} />
-                <Route path='send' element={<FeedbackSendLayout />}>
-                  <Route index element={<FeedbackSend />} />
-                  <Route path=':step' element={<FeedbackSendStep />} />
-                </Route>
-                <Route path='self' element={<FeedbackSelf />} />
-                <Route path='complete' element={<FeedbackComplete />} />
-                <Route path='favorite' element={<FeedbackFavorite />} />
-                <Route path='received' element={<FeedbackReceived />} />
-                <Route path='sent' element={<FeedbackSent />} />
-              </Route>
               <Route path='signin' element={<SignIn />} />
               <Route path='signup' element={<SignUp />} />
-              <Route path='teamspace'>
-                <Route path='make'>
-                  <Route index element={<TeamSpaceMake />} />
-                  <Route
-                    path='first'
-                    element={<TeamSpaceMake isFirst={true} />}
-                  />
-                  <Route path='success' element={<TeamSpaceMakeSuccess />} />
+              <Route element={<ProtectedRoute />}>
+                <Route path='feedback'>
+                  <Route path='request' element={<FeedbackRequest />} />
+                  <Route path='send' element={<FeedbackSendLayout />}>
+                    <Route index element={<FeedbackSend />} />
+                    <Route path=':step' element={<FeedbackSendStep />} />
+                  </Route>
+                  <Route path='self' element={<FeedbackSelf />} />
+                  <Route path='complete' element={<FeedbackComplete />} />
+                  <Route path='favorite' element={<FeedbackFavorite />} />
+                  <Route path='received' element={<FeedbackReceived />} />
+                  <Route path='sent' element={<FeedbackSent />} />
                 </Route>
-                <Route path='list' element={<TeamSpaceList />} />
-                <Route path='manage/:teamId'>
-                  <Route index element={<TeamSpaceManage />} />
-                  <Route path='edit' element={<TeamSpaceEdit />} />
+                <Route path='teamspace'>
+                  <Route path='make'>
+                    <Route index element={<TeamSpaceMake />} />
+                    <Route
+                      path='first'
+                      element={<TeamSpaceMake isFirst={true} />}
+                    />
+                    <Route path='success' element={<TeamSpaceMakeSuccess />} />
+                  </Route>
+                  <Route path='list' element={<TeamSpaceList />} />
+                  <Route path='manage/:teamId'>
+                    <Route index element={<TeamSpaceManage />} />
+                    <Route path='edit' element={<TeamSpaceEdit />} />
+                  </Route>
                 </Route>
-              </Route>
-              <Route path='calendar' element={<Calendar />} />
-              <Route path='main'>
-                <Route index element={<MainPage />} />
-                <Route path='notification' element={<NotificationPage />} />
-              </Route>
-              <Route path='mypage'>
-                <Route index element={<MyPageHome />} />
-                <Route path='self' element={<SelfFeedback />} />
-                <Route path='report' element={<div></div>} />
-                <Route path='edit' element={<div></div>} />
+                <Route path='calendar' element={<Calendar />} />
+                <Route path='main'>
+                  <Route index element={<MainPage />} />
+                  <Route path='notification' element={<NotificationPage />} />
+                </Route>
+                <Route path='mypage'>
+                  <Route index element={<MyPageHome />} />
+                  <Route path='self' element={<SelfFeedback />} />
+                  <Route path='report' element={<div></div>} />
+                  <Route path='edit' element={<div></div>} />
+                </Route>
               </Route>
             </Route>
           </Routes>

--- a/front-end/src/ProtectedRoute.jsx
+++ b/front-end/src/ProtectedRoute.jsx
@@ -1,16 +1,24 @@
 // ProtectedRoute.jsx
-import { useContext } from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useUserContext } from './UserContext';
 
 function ProtectedRoute() {
   const { state, dispatch } = useUserContext();
-  console.log(state);
+  const location = useLocation();
 
-  if (state.userId || state.userId == 'null') {
+  if (!exceptionCase(location) && (!state.userId || state.userId == 'null')) {
     return <Navigate to='/' replace />;
   }
   return <Outlet />;
 }
 
 export default ProtectedRoute;
+
+// 예외적인 경우 아래에 추가
+function exceptionCase(location) {
+  if (
+    location.pathname === '/feedback/favorite' &&
+    location.search === '?process=signup'
+  )
+    return true;
+}

--- a/front-end/src/ProtectedRoute.jsx
+++ b/front-end/src/ProtectedRoute.jsx
@@ -1,0 +1,16 @@
+// ProtectedRoute.jsx
+import { useContext } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useUserContext } from './UserContext';
+
+function ProtectedRoute() {
+  const { state, dispatch } = useUserContext();
+  console.log(state);
+
+  if (state.userId || state.userId == 'null') {
+    return <Navigate to='/' replace />;
+  }
+  return <Outlet />;
+}
+
+export default ProtectedRoute;

--- a/front-end/src/api/useAuth.js
+++ b/front-end/src/api/useAuth.js
@@ -1,9 +1,10 @@
 import { api } from './baseApi';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { replace, useNavigate } from 'react-router-dom';
 import { showToast } from '../utility/handleToast';
 import { useUser } from '../useUser';
 import { useJoinTeam } from './useTeamspace';
+import { useTeam } from '../useTeam';
 
 const BASE_URL_2 = '/api/auth';
 
@@ -56,6 +57,20 @@ export const useLogin = (teamCode) => {
     },
     onError: (error) => {
       showToast(`로그인 실패: ${error.message}`);
+    },
+  });
+};
+
+export const useLogout = () => {
+  const navigate = useNavigate();
+  const { setTeams } = useTeam();
+  const { setUserId } = useUser();
+  return useMutation({
+    mutationFn: () => api.post({ url: '/api/auth/logout' }),
+    onSuccess: () => {
+      setUserId(null);
+      setTeams([]);
+      navigate('/', { replace: true });
     },
   });
 };

--- a/front-end/src/pages/feedback/FeedbackFavorite.jsx
+++ b/front-end/src/pages/feedback/FeedbackFavorite.jsx
@@ -37,7 +37,7 @@ export default function FeedbackFavorite() {
     : mutation.mutate(
         {
           ...location.state,
-          feedbackPreference: [...selectedStyle, ...selectedContent],
+          feedbackPreferences: [...selectedStyle, ...selectedContent],
         },
         {
           onSuccess: (data) => {

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -14,7 +14,7 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import '../../slider.css';
 import { filterNotifications } from '../../utility/handleNotification';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { hideModal, showModal } from '../../utility/handleModal';
 import Modal, { ModalType } from '../../components/modals/Modal';
 import ProfileImage from '../../components/ProfileImage';
@@ -27,8 +27,10 @@ import { getScheduleTimeDiff } from '../../utility/time';
 import { useTeam } from '../../useTeam';
 import useScheduleAction from '../calendar/hooks/useScheduleAction';
 import { useUser } from '../../useUser';
+import useBlockPop from '../../useBlockPop';
 
 export default function MainPage() {
+  const location = useLocation();
   const [banners, setBanners] = useState();
   const [timeDiff, setTimeDiff] = useState();
   const [isTodoAddOpen, toggleTodoAdd] = useReducer((prev) => !prev, false);
@@ -48,6 +50,8 @@ export default function MainPage() {
   const navigate = useNavigate();
 
   // TODO: 로딩 중 혹은 에러 발생 시 처리
+
+  useBlockPop(location.pathname);
 
   useEffect(() => {
     clearData();

--- a/front-end/src/pages/mypage/MyPageHome.jsx
+++ b/front-end/src/pages/mypage/MyPageHome.jsx
@@ -5,11 +5,13 @@ import { useSearchMember } from '../../api/useMyPage';
 import { useUser } from '../../useUser';
 import Icon from '../../components/Icon';
 import { useId } from 'react';
+import { useLogout } from '../../api/useAuth';
 
 export default function MyPageHome() {
   const navigate = useNavigate();
   const { userId } = useUser();
   const { data: member } = useSearchMember(userId);
+  const { mutate: logout } = useLogout();
 
   const listButtontexts = [
     ['피드백 리포트', 'report'],
@@ -17,6 +19,10 @@ export default function MyPageHome() {
     ['피드백 선호도 관리', '/feedback/favorite'],
     ['나의 회고', 'self'],
   ];
+
+  const handleLogout = () => {
+    logout();
+  };
 
   return (
     <div className='flex size-full flex-col'>
@@ -63,6 +69,13 @@ export default function MyPageHome() {
           />
         ))}
       </ul>
+      <div className='flex-1' />
+      <a
+        className='body-1 mb-[50px] text-center text-gray-400'
+        onClick={() => handleLogout()}
+      >
+        로그아웃
+      </a>
     </div>
   );
 }

--- a/front-end/src/pages/teamspace/TeamSpaceMake.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceMake.jsx
@@ -4,7 +4,7 @@ import NavBar from '../auth/components/NavBar';
 import NavBar2 from '../../components/NavBar2';
 import Icon from '../../components/Icon';
 import LargeButton from '../../components/buttons/LargeButton';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { showToast } from '../../utility/handleToast';
 import { checkTeamSpaceMakingInfo } from '../../utility/inputChecker';
@@ -13,6 +13,7 @@ import CustomDatePicker, {
 } from '../../components/CustomDatePicker';
 import { useMakeTeam } from '../../api/useTeamspace';
 import { useTeam } from '../../useTeam';
+import useBlockPop from '../../useBlockPop';
 
 /**
  * @param {object} props
@@ -20,6 +21,7 @@ import { useTeam } from '../../useTeam';
  * @returns
  */
 export default function TeamSpaceMake({ isFirst = false }) {
+  const location = useLocation();
   const [teamSpaceName, setTeamSpaceName] = useState('');
   const [startDate, setStartDate] = useState(new Date());
   const [endDate, setEndDate] = useState(new Date());
@@ -29,6 +31,10 @@ export default function TeamSpaceMake({ isFirst = false }) {
   const navigate = useNavigate();
   const { mutate: makeTeam } = useMakeTeam();
   const { selectTeam } = useTeam();
+
+  if (location.pathname === '/teamspace/make/first') {
+    useBlockPop(location.pathname);
+  }
 
   const onClickNext = () => {
     if (!checkTeamSpaceMakingInfo(teamSpaceName, startDate, endDate)) {

--- a/front-end/src/useBlockPop.jsx
+++ b/front-end/src/useBlockPop.jsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const useBlockPop = (pathname, options = { replace: true }) => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handlePopState = (event) => {
+      console.log(event);
+      navigate(pathname, options);
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [navigate, pathname, options]);
+};
+
+export default useBlockPop;


### PR DESCRIPTION
로그아웃 기능 + 뒤로가기 방지 기능을 추가했습니다
- 로그아웃 후 이전 화면으로 돌아옴 방지를 위해 ProtectedRoute 생성
   - route 상으로 ProtectedRoute 아래에 있는 화면들은 로그인해야만 접근 가능
   - 로그인 안했을때는 루트( / )로 리다이렉션
   - 회원가입시 진행하는 피드백 선호도 고르는 화면은 예외에 추가
- 메인 화면과 회원가입 직후 뒤로가기 방지를 위해 useBlockPop 생성
   - 현재 location.pathname 을 가져와서 뒤로가기가 감지되면 현재 페이지로 이동시킴
   - 즉, '뒤로갔다가 현재페이지로 감' 의 무한 반복이므로 유저입장에선 뒤로가기가 안되는 것으로 보임.
      navigate(-1); navigate(현재경로);

<img width="431" alt="스크린샷 2025-02-15 오전 12 39 39" src="https://github.com/user-attachments/assets/d3ac02a7-187a-40cb-a680-f524ef575c2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Secured key areas by requiring users to sign in for accessing feedback, team, calendar, and personal pages.
  - Added an intuitive logout option on the user home page to enable immediate session termination.
  - Enhanced navigation control on select pages to prevent unintended back navigation, ensuring a smoother user experience.
  - Introduced a new custom hook for managing browser popstate events, improving navigation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->