### PR TITLE
[FD-351] 웹푸시 구독정보 중복 값 없애기

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/WebPushSubscription.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/WebPushSubscription.java
@@ -2,13 +2,13 @@ package com.feedhanjum.back_end.notification.domain;
 
 import com.feedhanjum.back_end.member.domain.Member;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nl.martijndwars.webpush.Subscription;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
-@Getter
+@Access(AccessType.FIELD)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Entity
 public class WebPushSubscription {
@@ -16,16 +16,60 @@ public class WebPushSubscription {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Embedded
+    private EmbeddedSubscription subscription;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subscriber_id")
     private Member subscriber;
 
-    @Column(name = "subscription", columnDefinition = "json")
-    @JdbcTypeCode(SqlTypes.JSON)
-    private Subscription subscription;
+
+    public void updateSubscriber(Member subscriber) {
+        this.subscriber = subscriber;
+    }
 
     public WebPushSubscription(Member subscriber, Subscription subscription) {
         this.subscriber = subscriber;
-        this.subscription = subscription;
+        this.subscription = EmbeddedSubscription.fromSubscription(subscription);
+    }
+
+    public Subscription getSubscription() {
+        return subscription.toSubscription();
+    }
+
+    // Subscription 객체 Embedded를 위한 중간 매핑 클래스
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Getter
+    @Embeddable
+    public static class EmbeddedSubscription {
+        public String endpoint;
+        @Embedded
+        public EmbeddedKeys keys;
+
+        public static EmbeddedSubscription fromSubscription(Subscription subscription) {
+            return new EmbeddedSubscription(subscription.endpoint, EmbeddedKeys.fromKeys(subscription.keys));
+        }
+
+        public Subscription toSubscription() {
+            return new Subscription(endpoint, keys.toKeys());
+        }
+
+        @NoArgsConstructor(access = AccessLevel.PROTECTED)
+        @AllArgsConstructor
+        @Getter
+        @Embeddable
+        public static class EmbeddedKeys {
+            public String p256dh;
+            public String auth;
+
+            public static EmbeddedKeys fromKeys(Subscription.Keys keys) {
+                return new EmbeddedKeys(keys.p256dh, keys.auth);
+            }
+
+            public Subscription.Keys toKeys() {
+                return new Subscription.Keys(p256dh, auth);
+            }
+        }
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/repository/WebPushSubscriptionRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/repository/WebPushSubscriptionRepository.java
@@ -5,7 +5,10 @@ import com.feedhanjum.back_end.notification.domain.WebPushSubscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WebPushSubscriptionRepository extends JpaRepository<WebPushSubscription, Long> {
     List<WebPushSubscription> findAllBySubscriber(Member subscriber);
+
+    Optional<WebPushSubscription> findBySubscription_Endpoint(String subscriptionEndpoint);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/service/WebPushService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/service/WebPushService.java
@@ -39,7 +39,12 @@ public class WebPushService {
     public void subscribe(Long subscriberId, Subscription subscription) {
         Member member = memberRepository.findById(subscriberId)
                 .orElseThrow(() -> new EntityNotFoundException("해당 회원을 찾을 수 없습니다."));
-        subscriptionRepository.save(new WebPushSubscription(member, subscription));
+
+        WebPushSubscription webPushSubscription = subscriptionRepository.findBySubscription_Endpoint(subscription.endpoint)
+                .orElseGet(() -> new WebPushSubscription(member, subscription));
+        webPushSubscription.updateSubscriber(member);
+
+        subscriptionRepository.save(webPushSubscription);
         log.info("Web push subscription saved: {} {}", member.getName(), subscription);
     }
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/notification/service/WebPushServiceIntegrationTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/notification/service/WebPushServiceIntegrationTest.java
@@ -1,0 +1,55 @@
+package com.feedhanjum.back_end.notification.service;
+
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.notification.domain.WebPushSubscription;
+import com.feedhanjum.back_end.notification.repository.WebPushSubscriptionRepository;
+import nl.martijndwars.webpush.Subscription;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static com.feedhanjum.back_end.test.util.DomainTestUtils.createMemberWithoutId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class WebPushServiceIntegrationTest {
+    @Autowired
+    private WebPushSubscriptionRepository webPushSubscriptionRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private WebPushService webPushService;
+
+    @Test
+    @DisplayName("endpoint 중복 시 기존 subscription을 업데이트")
+    void test1() {
+        // given
+        Member previousSubscriber = memberRepository.save(createMemberWithoutId("previousSubscriber"));
+
+        Member newSubscriber = memberRepository.save(createMemberWithoutId("newSubscriber"));
+
+        Subscription subscription = new Subscription("https://push-server.com/member1", new Subscription.Keys("key", "auth"));
+
+        webPushSubscriptionRepository.save(new WebPushSubscription(previousSubscriber, subscription));
+
+        // when
+        webPushService.subscribe(newSubscriber.getId(), subscription);
+
+        //then
+        assertThat(webPushSubscriptionRepository.findAllBySubscriber(previousSubscriber))
+                .isEmpty();
+        assertThat(webPushSubscriptionRepository.findAllBySubscriber(newSubscriber))
+                .hasSize(1)
+                .first()
+                .satisfies(webPushSubscription -> {
+                    assertThat(webPushSubscription.getSubscription().endpoint).isEqualTo(subscription.endpoint);
+                });
+    }
+
+}


### PR DESCRIPTION
# 관련 이슈
FD-351

# 변경된 점
- 하나의 기기가 여러개의 푸시 알림을 구독할 수 없게 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the subscription management process to seamlessly update user subscriptions when a duplicate endpoint is detected.

- **Refactor**
  - Enhanced the internal handling of subscription data for more robust and maintainable notification workflows.

- **Tests**
  - Added integration tests to validate the updated subscription logic, ensuring that existing subscribers are correctly updated in duplicate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->