### PR TITLE
[FD-352] 로그아웃 시, 로컬스토리지의 데이터를 비우도록

### DIFF
--- a/front-end/src/TeamContext.jsx
+++ b/front-end/src/TeamContext.jsx
@@ -22,6 +22,11 @@ const teamReducer = (state, action) => {
       localStorage.setItem('selectedTeam', JSON.stringify(action.payload));
       return { ...state, selectedTeam: action.payload };
 
+    case 'REMOVE_TEAM':
+      localStorage.removeItem('teams');
+      localStorage.removeItem('selectedTeam');
+      return { ...state, teams: [], selectedTeam: null };
+
     default:
       return state;
   }

--- a/front-end/src/UserContext.jsx
+++ b/front-end/src/UserContext.jsx
@@ -15,6 +15,9 @@ const userReducer = (state, action) => {
     case 'SET_USER_ID':
       localStorage.setItem('userId', JSON.stringify(action.payload));
       return { ...state, userId: action.payload };
+    case 'REMOVE_USER_ID':
+      localStorage.removeItem('userId');
+      return { ...state, userId: null };
 
     default:
       return state;

--- a/front-end/src/api/useAuth.js
+++ b/front-end/src/api/useAuth.js
@@ -63,13 +63,13 @@ export const useLogin = (teamCode) => {
 
 export const useLogout = () => {
   const navigate = useNavigate();
-  const { setTeams } = useTeam();
-  const { setUserId } = useUser();
+  const { removeTeam } = useTeam();
+  const { removeUserId } = useUser();
   return useMutation({
     mutationFn: () => api.post({ url: '/api/auth/logout' }),
     onSuccess: () => {
-      setUserId(null);
-      setTeams([]);
+      removeTeam();
+      removeUserId();
       navigate('/', { replace: true });
     },
   });

--- a/front-end/src/useTeam.jsx
+++ b/front-end/src/useTeam.jsx
@@ -18,6 +18,11 @@ export const useTeam = () => {
     }
   };
 
+  // 로그아웃 시 팀 리스트, 선택 팀 초기화
+  const removeTeam = () => {
+    dispatch({ type: 'REMOVE_TEAM' });
+  };
+
   // useTeam 호출하면 팀 목록을 가져옴
   const { data: teamsData } = useMyTeams();
 
@@ -32,5 +37,6 @@ export const useTeam = () => {
     selectedTeam: state.selectedTeam,
     setTeams,
     selectTeam,
+    removeTeam,
   };
 };

--- a/front-end/src/useUser.jsx
+++ b/front-end/src/useUser.jsx
@@ -9,8 +9,13 @@ export const useUser = () => {
     dispatch({ type: 'SET_USER_ID', payload: userId });
   };
 
+  const removeUserId = () => {
+    dispatch({ type: 'REMOVE_USER_ID' });
+  };
+
   return {
     userId: parseInt(state.userId),
     setUserId,
+    removeUserId,
   };
 };


### PR DESCRIPTION
로그아웃 시에 기존 커스텀 훅 활용하여 팀, 유저 관련 정보 싹 비우도록 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logout process: User identification and team details are now securely cleared from storage upon logout, ensuring no residual session data remains.
	- Improved state management: The application now reliably resets both user and team states during logout, contributing to a cleaner and more secure user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->