### PR TITLE
[FD-355] 새로운 팀에 대한 api call이 필요없는 페이지에선 안하도록

### DIFF
--- a/front-end/src/api/useMainPage.js
+++ b/front-end/src/api/useMainPage.js
@@ -4,10 +4,12 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 /**
  *  팀 목록을 가져오는 훅 (쿠키에 있는 sessionId로 조회)
  */
-export const useMyTeams = (userId) => {
+export const useMyTeams = ({ enabled }) => {
   return useQuery({
-    queryKey: ['myTeams', userId],
+    queryKey: ['myTeams'],
     queryFn: () => api.get({ url: '/api/team/my-teams' }),
+    enabled: enabled,
+    gcTime: 0,
   });
 };
 

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -36,7 +36,7 @@ export default function MainPage() {
   const [isTodoAddOpen, toggleTodoAdd] = useReducer((prev) => !prev, false);
   const [isScheduleOpen, toggleSchedule] = useReducer((prev) => !prev, false);
 
-  const { teams, selectedTeam, selectTeam } = useTeam();
+  const { teams, selectedTeam, selectTeam } = useTeam(true);
   const { userId } = useUser();
   const { data: recentScheduleData, isPending: isMainCardPending } =
     useMainCard(selectedTeam);

--- a/front-end/src/pages/main/components/MainCard.jsx
+++ b/front-end/src/pages/main/components/MainCard.jsx
@@ -26,7 +26,6 @@ export default function MainCard({
   onClickSubButton,
   onClickChevronButton,
 }) {
-  console.log(userId, isInTeam, recentSchedule, scheduleDifferece);
   const contentRef = useRef(null);
   const [isOpen, setIsOpen] = useState(false);
   const [height, setHeight] = useState(0);

--- a/front-end/src/pages/teamspace/TeamSpaceList.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceList.jsx
@@ -1,18 +1,15 @@
 import { useState } from 'react';
-import { useMyTeams } from '../../api/useMainPage';
 import NavBar2 from '../../components/NavBar2';
 import StickyWrapper from '../../components/wrappers/StickyWrapper';
 import { useNavigate } from 'react-router-dom';
 import TeamElement from './components/TeamElement';
 import { checkIsFinished } from '../../utility/time';
-import { useUser } from '../../useUser';
 import { useTeam } from '../../useTeam';
 
 export default function TeamSpaceList() {
   const navigate = useNavigate();
   const [showEndedTeams, setShowEndedTeams] = useState(false);
-  const { userId } = useUser();
-  const { teams } = useTeam(userId);
+  const { teams } = useTeam(true);
 
   return (
     <div className='scrollbar-hidden flex h-full flex-col overflow-x-hidden overflow-y-auto'>

--- a/front-end/src/useTeam.jsx
+++ b/front-end/src/useTeam.jsx
@@ -1,12 +1,13 @@
 import { useEffect } from 'react';
 import { useMyTeams } from './api/useMainPage';
 import { useTeamContext } from './TeamContext';
-import { useUser } from './useUser';
 
-// 팀 관련 로직을 처리하는 커스텀 훅
-export const useTeam = () => {
+/**
+ * 팀 관련 정보를 get, set 할 수 있는 훅
+ * @param {boolean} needToRefreshTeam - 훅 수행시에, 팀 정보 api를 다시 호출할지 여부
+ */
+export const useTeam = (needToRefreshTeam = false) => {
   const { state, dispatch } = useTeamContext();
-  const { userId } = useUser();
 
   // 팀 리스트 설정
   const setTeams = (teams) => {
@@ -31,7 +32,7 @@ export const useTeam = () => {
   };
 
   // useTeam 호출하면 팀 목록을 가져옴
-  const { data: teamsData } = useMyTeams(userId);
+  const { data: teamsData } = useMyTeams({ enabled: needToRefreshTeam });
 
   useEffect(() => {
     if (teamsData) {


### PR DESCRIPTION
- 기존 userId로 invalidate했던 방법을 `gcTime: 0`으로 변경
- 메인화면, 팀 스페이스 관리 화면을 제외하고는, 이제부턴 `useTeam`을 사용해도 api call이 일어나지 않음

## 고찰
- useQuery 함수 자체는 리렌더링 될 때마다 **실행된다**
- 그러나 queryFn은 리렌더링 될 때는 실행되지 않는다. 리렌더링 때는 메모리에 유지하고 있는 데이터를 제공한다.
- 컴포넌트가 언마운트 될때, gcTime에 의거하여 캐시할지 안할지 결정하고 gcTime만큼 유지한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined how team information is fetched and refreshed, leading to more consistent and timely updates on team-related pages.
- **Chore**
  - Removed extraneous debugging logs to ensure a cleaner operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->