### PR TITLE
[FD-357] 수시 피드백 요청 알림에 sender id 추가

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FrequentFeedbackRequestNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/FrequentFeedbackRequestNotification.java
@@ -13,10 +13,12 @@ import lombok.NoArgsConstructor;
 public class FrequentFeedbackRequestNotification extends InAppNotification {
     private String senderName;
     private Long teamId;
+    private Long senderId;
 
-    public FrequentFeedbackRequestNotification(Long receiverId, String senderName, Long teamId) {
+    public FrequentFeedbackRequestNotification(Long receiverId, String senderName, Long teamId, Long senderId) {
         super(receiverId);
         this.senderName = senderName;
         this.teamId = teamId;
+        this.senderId = senderId;
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
@@ -51,7 +51,7 @@ public class InAppNotificationService {
     }
 
     /**
-     * @throw EntityNotFoundException receiverId에 해당하는 엔티티가 없을 때
+     * @throws EntityNotFoundException receiverId에 해당하는 엔티티가 없을 때
      */
     @Transactional
     public void readInAppNotifications(Long receiverId, List<Long> notificationIds) {
@@ -70,7 +70,7 @@ public class InAppNotificationService {
 
         Member sender = memberRepository.findById(senderId).orElseThrow();
 
-        InAppNotification notification = new FrequentFeedbackRequestNotification(receiverId, sender.getName(), teamId);
+        InAppNotification notification = new FrequentFeedbackRequestNotification(receiverId, sender.getName(), teamId, senderId);
         inAppNotificationRepository.save(notification);
         eventPublisher.publishEvent(new InAppNotificationCreatedEvent(notification.getId()));
     }


### PR DESCRIPTION
# 관련 이슈
FD-357

# 변경된 점
- 수시 피드백 요청 알림에 sender id 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced in-app feedback notifications now include additional sender information, providing recipients with improved context for feedback requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->