### PR TITLE
[FD-359] 수시 피드백 요청 중복 시 기존 요청 내용 업데이트 기능 추가

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -108,6 +108,7 @@ public class Team {
     public void requestFeedback(Member sender, Member receiver, String requestedContent) {
         validateTeamMember(sender);
         validateTeamMember(receiver);
+        this.frequentFeedbackRequests.removeIf(request -> sender.equals(request.getSender()) && receiver.equals(request.getReceiver()));
         this.frequentFeedbackRequests.add(new FrequentFeedbackRequest(requestedContent, sender, this, receiver));
     }
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/domain/TeamTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/domain/TeamTest.java
@@ -5,6 +5,7 @@ import com.feedhanjum.back_end.member.domain.FeedbackPreference;
 import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.domain.ProfileImage;
 import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
+import com.feedhanjum.back_end.test.util.DomainTestUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -90,5 +91,26 @@ class TeamTest {
 
         // then
         assertThat(team.getLeader()).isNotEqualTo(newLeader);
+    }
+
+    @Test
+    @DisplayName("중복된 수시 피드백 요청은 기존 요청 내용을 업데이트 함")
+    void test1() {
+        // given
+        Member sender = DomainTestUtils.createMemberWithId("sender");
+        Member receiver = DomainTestUtils.createMemberWithId("receiver");
+        Team team = DomainTestUtils.createTeamWithId("team", sender);
+        team.join(receiver);
+        team.requestFeedback(sender, receiver, "이전 내용");
+
+        // when
+        team.requestFeedback(sender, receiver, "새로운 내용");
+
+        // then
+        assertThat(team.getFeedbackRequests(receiver)).hasSize(1)
+                .first()
+                .satisfies(request -> {
+                    assertThat(request.getRequestedContent()).isEqualTo("새로운 내용");
+                });
     }
 }


### PR DESCRIPTION
# 관련 이슈
FD-359

# 변경된 점
- 수시 피드백 요청 중복 시 기존 요청 내용 업데이트하도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced feedback handling to automatically clear older requests and display only the most recent feedback entry.
  
- **Tests**
  - Added a test scenario to ensure that duplicate feedback submissions update correctly.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->