### PR TITLE
[FD-362] GitHub Actions를 이용한 프론트엔드 S3 배포 워크플로 추가

### DIFF
--- a/.github/workflows/s3-deploy.yml
+++ b/.github/workflows/s3-deploy.yml
@@ -1,0 +1,56 @@
+name: AWS S3 Frontend Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - front-end/**
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - front-end/**
+
+
+permissions:
+  contents: read
+
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: 'front-end'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: "front-end"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build React app
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: Sync S3 bucket
+        run: aws s3 sync dist/ s3://${{ secrets.AWS_S3_BUCKET_NAME }} --delete
+
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
# 관련 이슈
FD-362

# 변경된 점
- Github Action을 이용해 프론트엔드 앱을 S3로 배포 -> dhc884wdr0iyd.cloudfront.net
  - main, dev에 pull request 생성 혹은 push가 이뤄지면 배포 실행 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Launched an automated deployment pipeline that builds, deploys, and refreshes the frontend application seamlessly. Users benefit from immediate access to the most up-to-date content with enhanced delivery performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->