### PR TITLE
[FD-364] 피드백 좋아요 알림의 수신, 발신자가 뒤바뀐 버그 수정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/HeartReactionNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/HeartReactionNotification.java
@@ -16,8 +16,8 @@ public class HeartReactionNotification extends InAppNotification {
     private String teamName;
 
     public HeartReactionNotification(Feedback feedback) {
-        super(feedback.getReceiver().getId());
-        this.senderName = feedback.getSender().getName();
+        super(feedback.getSender().getId());
+        this.senderName = feedback.getReceiver().getName();
         this.teamName = feedback.getTeam().getName();
     }
 }


### PR DESCRIPTION
# 관련 이슈
FD-364

# 변경된 점
- 피드백 좋아요 알림이 피드백 수신자에게 가는 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated heart reaction notifications to display the correct user information, ensuring that the sender’s details are accurately reflected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->