### PR TITLE
[FD-365] 바텀시트 위치 조정

### DIFF
--- a/front-end/src/Layout.jsx
+++ b/front-end/src/Layout.jsx
@@ -2,7 +2,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import ModalBase from './components/modals/ModalBase';
 import ToastBase from './components/toasts/ToastBase';
 
-const noPaddingPages = ['/main']; // 패딩을 제거할 페이지 리스트
+const noPaddingPages = ['/main', '/calendar']; // 패딩을 제거할 페이지 리스트
 
 function Layout() {
   const location = useLocation();

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -49,71 +49,73 @@ export default function Calendar() {
   const { scrollRef, isScrolling } = useCalendarScroll();
 
   return (
-    <div
-      ref={scrollRef}
-      className='scrollbar-hidden relative size-full overflow-x-hidden overflow-y-auto'
-    >
-      <StickyWrapper>
-        <Accordion
-          isMainPage={false}
-          selectedTeamId={selectedTeam}
-          teamList={teams}
-          onTeamClick={(teamId) => {
-            selectTeam(teamId);
-            setShowAllSchedule(false);
-          }}
-          canClose={!doingAction}
-          onClickLastButton={() => {
-            setShowAllSchedule(true);
-          }}
-          showAllSchedule={showAllSchedule}
-        />
-        <SelectedDateInfo date={selectedDate} isScrolling={isScrolling} />
-      </StickyWrapper>
-      <CalendarWeeks
-        selectedDate={selectedDate}
-        setSelectedDate={setSelectedDate}
-        scheduleSet={scheduleSet}
-        setAllSchedules={setAllSchedules}
-      />
-      <ul className='flex flex-col gap-6'>
-        {scheduleOnDate &&
-          scheduleOnDate.map((schedule, index) => {
-            if (!showAllSchedule && schedule.teamId !== selectedTeam)
-              return null;
-            return (
-              <li key={index} className='last:mb-5'>
-                <ScheduleCard
-                  schedule={schedule}
-                  todos={schedule.scheduleMemberNestedDtoList}
-                  isFinished={checkIsFinished(schedule.endTime)}
-                  onClickEdit={() => {
-                    setSelectedSchedule(schedule);
-                    setActionType(ScheduleActionType.EDIT);
-                    setDoingAction(true);
-                  }}
-                />
-              </li>
-            );
-          })}
-        <li className='mb-5'>
-          <LargeButton
-            text={
-              <p className='button-1 flex items-center gap-2 text-gray-300'>
-                <Icon name='plusS' />
-                새로운 일정 추가
-              </p>
-            }
-            onClick={() => {
-              clearData();
-              setActionType(ScheduleActionType.ADD);
-              setDoingAction(true);
+    <div className='relative overflow-y-hidden'>
+      <div
+        ref={scrollRef}
+        className='scrollbar-hidden h-dvh overflow-x-hidden overflow-y-auto px-5'
+      >
+        <StickyWrapper>
+          <Accordion
+            isMainPage={false}
+            selectedTeamId={selectedTeam}
+            teamList={teams}
+            onTeamClick={(teamId) => {
+              selectTeam(teamId);
+              setShowAllSchedule(false);
             }}
-            isOutlined={true}
-            disabled={true}
+            canClose={!doingAction}
+            onClickLastButton={() => {
+              setShowAllSchedule(true);
+            }}
+            showAllSchedule={showAllSchedule}
           />
-        </li>
-      </ul>
+          <SelectedDateInfo date={selectedDate} isScrolling={isScrolling} />
+        </StickyWrapper>
+        <CalendarWeeks
+          selectedDate={selectedDate}
+          setSelectedDate={setSelectedDate}
+          scheduleSet={scheduleSet}
+          setAllSchedules={setAllSchedules}
+        />
+        <ul className='flex flex-col gap-6'>
+          {scheduleOnDate &&
+            scheduleOnDate.map((schedule, index) => {
+              if (!showAllSchedule && schedule.teamId !== selectedTeam)
+                return null;
+              return (
+                <li key={index} className='last:mb-5'>
+                  <ScheduleCard
+                    schedule={schedule}
+                    todos={schedule.scheduleMemberNestedDtoList}
+                    isFinished={checkIsFinished(schedule.endTime)}
+                    onClickEdit={() => {
+                      setSelectedSchedule(schedule);
+                      setActionType(ScheduleActionType.EDIT);
+                      setDoingAction(true);
+                    }}
+                  />
+                </li>
+              );
+            })}
+          <li className='mb-5'>
+            <LargeButton
+              text={
+                <p className='button-1 flex items-center gap-2 text-gray-300'>
+                  <Icon name='plusS' />
+                  새로운 일정 추가
+                </p>
+              }
+              onClick={() => {
+                clearData();
+                setActionType(ScheduleActionType.ADD);
+                setDoingAction(true);
+              }}
+              isOutlined={true}
+              disabled={true}
+            />
+          </li>
+        </ul>
+      </div>
       {scheduleOnDate && (
         <ScheduleAction
           type={actionType}

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -148,7 +148,7 @@ export default function ScheduleAction({
     <div
       ref={scrollRef}
       className={classNames(
-        'rounded-t-400 fixed right-0 left-0 z-1000 flex h-[calc(100%-60px)] max-w-[430px] flex-col overflow-y-auto bg-gray-800 px-5 transition-all duration-300',
+        'rounded-t-400 absolute z-1000 flex h-[calc(100%-60px)] w-full max-w-[430px] flex-col overflow-y-auto bg-gray-800 px-5 transition-all duration-300',
         isOpen ? 'visible bottom-0' : 'invisible -bottom-[100%]',
       )}
     >

--- a/front-end/src/pages/calendar/components/TodoAdd.jsx
+++ b/front-end/src/pages/calendar/components/TodoAdd.jsx
@@ -63,7 +63,7 @@ export default function TodoAdd({ isOpen, onClose, selectedSchedule }) {
     <div
       ref={scrollRef}
       className={classNames(
-        'rounded-t-400 fixed right-0 left-0 z-1000 flex h-[calc(100%-60px)] max-w-[430px] flex-col overflow-y-auto bg-gray-800 px-5 transition-all duration-300',
+        'rounded-t-400 absolute z-1000 flex h-[calc(100%-60px)] w-full max-w-[430px] flex-col overflow-y-auto bg-gray-800 px-5 transition-all duration-300',
         isOpen ? 'visible bottom-0' : 'invisible -bottom-[100%]',
       )}
     >

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -99,7 +99,7 @@ export default function MainPage() {
   };
 
   return (
-    <div className='flex w-full flex-col'>
+    <div className='relative flex h-full w-full flex-col overflow-hidden'>
       <StickyWrapper className='px-5'>
         {teams && (
           <Accordion


### PR DESCRIPTION
웹에서 들어갔을때 좌측에 뜨는 문제 해결헸습니다
- Layout에 좌우 패딩 없는 라우트 추가
- 기존 fixed 속성을 absolute로 변경
- 이에 따라 필요한 경우 부모에 relative 속성 추가

<img width="800" alt="스크린샷 2025-02-17 오전 12 04 36" src="https://github.com/user-attachments/assets/b5048b52-1d69-4224-8696-6f636e1e2aa1" />

<img width="800" alt="스크린샷 2025-02-17 오전 12 04 21" src="https://github.com/user-attachments/assets/1e988120-e34d-4510-8b1b-32891f7a532a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the layout configuration to remove extra padding on the Calendar page.
	- Refined the Calendar view for clearer organization and improved responsiveness.
	- Adjusted component positioning for schedule and todo actions to ensure full-width alignment.
	- Enhanced the main page structure for better element containment and a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->