### PR TITLE
[FD-366] 피드백 선호 변경 기능

### DIFF
--- a/front-end/src/api/useFeedback.js
+++ b/front-end/src/api/useFeedback.js
@@ -82,14 +82,9 @@ export const useFeedbackFavorite = () => {
 };
 
 export const useEditFavorite = () => {
-  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data) =>
       api.post({ url: '/api/member/feedback-prefer', body: data }),
-    onSuccess: () => {
-      // TODO: 사용자 선호 피드백 정보 조회할때 캐시를 지우도록 수정
-      // queryClient.invalidateQueries({ queryKey: ['feedback-favorite'] });
-    },
   });
 };
 

--- a/front-end/src/api/useFeedback.js
+++ b/front-end/src/api/useFeedback.js
@@ -78,6 +78,7 @@ export const useFeedbackFavorite = () => {
   return useQuery({
     queryKey: ['feedback-preference'],
     queryFn: () => api.get({ url: '/api/feedback/preference' }),
+    gcTime: 1000 * 60 * 60, // 바뀔 일이 거의 없는 데이터라서 1시간으로 설정
   });
 };
 
@@ -93,6 +94,7 @@ export const useFeedbackFavoriteByUser = (data) => {
     queryKey: ['feedback-favorite-by-user'],
     queryFn: () =>
       api.get({ url: `/api/member/feedback-prefer?findMemberId=${data}` }),
+    gcTime: 0, // 지난번 거랑 바뀌는게 보기 좋지 않아서 그냥 캐싱 X
   });
 };
 


### PR DESCRIPTION
피드백 선호 변경 기능 구현했습니다.
키워드들은 어차피 안바뀔꺼니 여유있게 한시간 캐싱하게 해보았고,
반면에 사용자 키워드를 조회하는 쪽은 캐싱해두면 찰나의 순간에 바뀌는게 좀 안좋게 보여서 캐싱안했습니다

https://github.com/user-attachments/assets/62000f55-62f5-49f0-980d-66e84fe1ded1


이건 그래서 바꾸었지만, 다른 데에도 찰나의 순간에 바뀌어 보이는게 좀 많은데,, 그냥 로딩처리를 할지 캐싱을 할지 같이 생각해보는 것도 좋을거같습니당


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Personalized feedback options now adapt based on your profile, ensuring you see tailored and current selections.
  - Optimized data loading so that general feedback is efficiently cached while your individual preferences remain always fresh.
  
- **Refactor**
  - Streamlined the feedback selection process for a smoother and more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->