### PR TITLE
[FD-348]  정기 피드백 요청을 전부 처리했을 경우, 다가오는 일정을 보여주도록 수정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/RegularFeedbackRequestQueryRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/RegularFeedbackRequestQueryRepository.java
@@ -28,9 +28,7 @@ public class RegularFeedbackRequestQueryRepository {
     public Long getRegularFeedbackRequestCount(Long receiverId, Long scheduleId) {
         return queryFactory.select(regularFeedbackRequest.count())
                 .from(regularFeedbackRequest)
-                .join(regularFeedbackRequest.requester).fetchJoin()
-                .join(regularFeedbackRequest.scheduleMember).fetchJoin()
-                .join(regularFeedbackRequest.scheduleMember.schedule).fetchJoin()
+                .join(regularFeedbackRequest.scheduleMember)
                 .where(regularFeedbackRequest.scheduleMember.member.id.eq(receiverId)
                         .and(regularFeedbackRequest.scheduleMember.schedule.id.eq(scheduleId)))
                 .fetchOne();

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/RegularFeedbackRequestQueryRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/repository/RegularFeedbackRequestQueryRepository.java
@@ -24,4 +24,15 @@ public class RegularFeedbackRequestQueryRepository {
                         .and(regularFeedbackRequest.scheduleMember.schedule.id.eq(scheduleId)))
                 .fetch();
     }
+
+    public Long getRegularFeedbackRequestCount(Long receiverId, Long scheduleId) {
+        return queryFactory.select(regularFeedbackRequest.count())
+                .from(regularFeedbackRequest)
+                .join(regularFeedbackRequest.requester).fetchJoin()
+                .join(regularFeedbackRequest.scheduleMember).fetchJoin()
+                .join(regularFeedbackRequest.scheduleMember.schedule).fetchJoin()
+                .where(regularFeedbackRequest.scheduleMember.member.id.eq(receiverId)
+                        .and(regularFeedbackRequest.scheduleMember.schedule.id.eq(scheduleId)))
+                .fetchOne();
+    }
 }


### PR DESCRIPTION
# 관련 이슈
FD-348

# 변경된 점
- [x] 정기 피드백 요청을 전부 처리했을 경우, 사용자에게 다가오는 다음 일정을 보여주도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to aggregate feedback request data to support enhanced schedule management.
	- Updated schedule selection logic to prioritize recent schedules in cases with pending feedback, resulting in a more relevant scheduling experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->