### PR TITLE
[FD-373]  종료된 팀에 가입 가능한 문제 수정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -2,6 +2,7 @@ package com.feedhanjum.back_end.team.domain;
 
 import com.feedhanjum.back_end.feedback.domain.FeedbackType;
 import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.team.exception.TeamEndedException;
 import com.feedhanjum.back_end.team.exception.TeamLeaderMustExistException;
 import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
 import jakarta.persistence.*;
@@ -12,6 +13,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -145,7 +147,9 @@ public class Team {
         return teamMembers.stream().anyMatch(teamMember -> member.equals(teamMember.getMember()));
     }
 
-    public TeamJoinToken createJoinToken(Member member) {
+    public TeamJoinToken createJoinToken(Member member, LocalDateTime now) {
+        if (now.isAfter(endDate.plusDays(1).atStartOfDay()))
+            throw new TeamEndedException("팀이 이미 종료되었습니다");
         validateTeamMember(member);
         return TeamJoinToken.createToken(this);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamJoinToken.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamJoinToken.java
@@ -1,6 +1,7 @@
 package com.feedhanjum.back_end.team.domain;
 
 import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.team.exception.TeamEndedException;
 import com.feedhanjum.back_end.team.exception.TeamJoinTokenNotValidException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -55,6 +56,9 @@ public class TeamJoinToken {
     private void validate() {
         if (getExpireDate().isBefore(LocalDateTime.now())) {
             throw new TeamJoinTokenNotValidException();
+        }
+        if (team.getEndDate().plusDays(1).atStartOfDay().isBefore(LocalDateTime.now())) {
+            throw new TeamEndedException("팀 스페이스가 이미 종료되었습니다.");
         }
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamEndedException.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamEndedException.java
@@ -1,0 +1,7 @@
+package com.feedhanjum.back_end.team.exception;
+
+public class TeamEndedException extends RuntimeException {
+    public TeamEndedException(String message) {
+        super(message);
+    }
+}

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamMemberControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/exception/TeamMemberControllerAdvice.java
@@ -23,4 +23,9 @@ public class TeamMemberControllerAdvice {
     public ResponseEntity<String> teamJoinTokenNotValidException(TeamJoinTokenNotValidException e) {
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
+
+    @ExceptionHandler(TeamEndedException.class)
+    public ResponseEntity<String> teamEndedException(TeamEndedException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.GONE);
+    }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -152,7 +152,7 @@ public class TeamService {
                 .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member member = memberRepository
                 .findById(memberId).orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
-        TeamJoinToken joinToken = team.createJoinToken(member);
+        TeamJoinToken joinToken = team.createJoinToken(member, LocalDateTime.now(clock));
         teamJoinTokenRepository.save(joinToken);
         return joinToken;
     }

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerIntegrationTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerIntegrationTest.java
@@ -31,6 +31,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -57,6 +58,9 @@ public class TeamControllerIntegrationTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private Clock clock;
 
     @Autowired
     private TeamRepository teamRepository;
@@ -405,7 +409,7 @@ public class TeamControllerIntegrationTest {
             Team team = createTeamWithoutId("teamByJoinToken", leader);
             teamRepository.save(team);
 
-            TeamJoinToken token = team.createJoinToken(leader);
+            TeamJoinToken token = team.createJoinToken(leader, LocalDateTime.now(clock));
             teamJoinTokenRepository.save(token);
 
             // when & then
@@ -430,7 +434,7 @@ public class TeamControllerIntegrationTest {
             Team team = createTeamWithoutId("teamByJoinToken", leader);
             teamRepository.save(team);
 
-            TeamJoinToken expiredToken = team.createJoinToken(leader);
+            TeamJoinToken expiredToken = team.createJoinToken(leader, LocalDateTime.now(clock));
             ReflectionTestUtils.setField(expiredToken, "expireDate", LocalDateTime.now().minusHours(1));
             teamJoinTokenRepository.save(expiredToken);
 
@@ -645,7 +649,7 @@ public class TeamControllerIntegrationTest {
             Team team = createTeamWithoutId("team1", leader);
             teamRepository.save(team);
 
-            TeamJoinToken token = team.createJoinToken(leader);
+            TeamJoinToken token = team.createJoinToken(leader, LocalDateTime.now(clock));
             teamJoinTokenRepository.save(token);
 
             Member notMember = member2;
@@ -670,7 +674,7 @@ public class TeamControllerIntegrationTest {
             Team team = createTeamWithoutId("team1", leader);
             teamRepository.save(team);
 
-            TeamJoinToken token = team.createJoinToken(leader);
+            TeamJoinToken token = team.createJoinToken(leader, LocalDateTime.now(clock));
             teamJoinTokenRepository.save(token);
 
             Member notMember = member2;
@@ -692,7 +696,7 @@ public class TeamControllerIntegrationTest {
             Team team = createTeamWithoutId("team1", leader);
             teamRepository.save(team);
 
-            TeamJoinToken expiredToken = team.createJoinToken(leader);
+            TeamJoinToken expiredToken = team.createJoinToken(leader, LocalDateTime.now(clock));
             ReflectionTestUtils.setField(expiredToken, "expireDate", LocalDateTime.now().minusHours(1));
             teamJoinTokenRepository.save(expiredToken);
 


### PR DESCRIPTION
# 관련 이슈
FD-373

# 변경된 점
- [x] 종료된 팀에 가입 가능한 문제 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the team join process by including real-time timestamp validation. Now, when a user attempts to join a team, the system checks that the team is still active and, if not, provides a clear error message.
  - Introduced a custom exception for handling cases where a team has already ended, improving clarity in error reporting.

- **Bug Fixes**
  - Prevented the creation and usage of join tokens for teams that have already ended, ensuring a more reliable experience during team sign-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->