### PR TITLE
[FD-367] 새로운 미확인 알림 생성 로직

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/domain/InAppNotification.java
@@ -28,6 +28,8 @@ public abstract class InAppNotification {
     @Column(nullable = false)
     protected boolean isRead;
 
+    protected LocalDateTime readAt;
+
     @Column(name = "type", nullable = false, updatable = false, insertable = false)
     protected String type;
 
@@ -35,14 +37,19 @@ public abstract class InAppNotification {
         this.id = null;
         this.receiverId = receiverId;
         this.isRead = false;
+        this.readAt = null;
         this.createdAt = LocalDateTime.now();
     }
 
-    public void read(Member notificationReceiver) {
+    public void read(Member notificationReceiver, LocalDateTime readAt) {
         if (!isReceiver(notificationReceiver)) {
             throw new SecurityException("알림을 읽을 권한이 없습니다");
         }
+        if (this.isRead) {
+            return;
+        }
         this.isRead = true;
+        this.readAt = readAt;
     }
 
     private boolean isReceiver(Member member) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/repository/InAppNotificationRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/repository/InAppNotificationRepository.java
@@ -3,9 +3,12 @@ package com.feedhanjum.back_end.notification.repository;
 import com.feedhanjum.back_end.notification.domain.InAppNotification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface InAppNotificationRepository extends JpaRepository<InAppNotification, Long> {
 
     Optional<InAppNotification> findByReceiverIdAndType(Long receiverId, String type);
+
+    List<InAppNotification> findAllByReceiverIdAndType(Long receiverId, String type);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/notification/service/InAppNotificationService.java
@@ -64,7 +64,18 @@ public class InAppNotificationService {
         Member receiver = memberRepository.findById(receiverId).orElseThrow(() -> new EntityNotFoundException("없는 사용자"));
         List<InAppNotification> notifications = inAppNotificationRepository.findAllById(notificationIds);
         for (InAppNotification notification : notifications) {
-            notification.read(receiver);
+            readNotification(notification, receiver);
+        }
+    }
+
+    private void readNotification(InAppNotification notification, Member receiver) {
+        notification.read(receiver, LocalDateTime.now(clock));
+        // 피드백 미확인 알림을 읽을 경우, 존재하는 모든 피드백 도착 알림을 읽음 처리
+        if (notification instanceof UnreadFeedbackExistNotification) {
+            for (InAppNotification inAppNotification : inAppNotificationRepository.findAllByReceiverIdAndType(receiver.getId(), NotificationType.FEEDBACK_RECEIVE)) {
+                readNotification(inAppNotification, receiver);
+            }
+
         }
     }
 
@@ -186,24 +197,31 @@ public class InAppNotificationService {
         unreadNotifications.sort(Comparator.comparing(InAppNotification::getCreatedAt));
         // 같은 사용자를 대상으로 여러개의 안읽은 알림이 있다면 가장 오래된 것에 대해서만 이벤트 발행
         Set<Long> receiverIds = new HashSet<>();
+        LocalDateTime now = LocalDateTime.now(clock);
         for (FeedbackReceiveNotification unreadNotification : unreadNotifications) {
             if (receiverIds.contains(unreadNotification.getReceiverId())) {
                 continue;
             }
-            createNotification(unreadNotification);
+            createNotification(unreadNotification, now);
             receiverIds.add(unreadNotification.getReceiverId());
         }
         jobRecord.updatePreviousFinishTime(oneDayAgo);
         jobRecordRepository.save(jobRecord);
     }
 
-    private void createNotification(FeedbackReceiveNotification unreadNotification) {
-        // 이미 안읽은 미확인 피드백 알림이 있다면 새로 생성하지 않음
+    private void createNotification(FeedbackReceiveNotification unreadNotification, LocalDateTime now) {
         Optional<InAppNotification> exists = inAppNotificationRepository.findByReceiverIdAndType(
                 unreadNotification.getReceiverId(),
                 NotificationType.UNREAD_FEEDBACK_EXIST);
-        if (exists.isPresent() && !exists.get().isRead())
-            return;
+        if (exists.isPresent()) {
+            InAppNotification existNotification = exists.get();
+            // 이미 안읽은 미확인 피드백 알림이 있다면 새로 생성하지 않음
+            if (!existNotification.isRead())
+                return;
+            // 미확인 피드백 알림이 읽힌 지 24시간이 지나지 않았다면 새로 생성하지 않음
+            if (existNotification.getReadAt() != null && existNotification.getReadAt().isAfter(now.minusDays(1)))
+                return;
+        }
 
         InAppNotification notification = new UnreadFeedbackExistNotification(unreadNotification);
         inAppNotificationRepository.save(notification);

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
@@ -220,6 +220,7 @@ public class ScheduleService {
             return;  // Early return if no schedules need updating
         }
         List<ScheduleMember> scheduleMembers = relatedSchedule.stream()
+                .filter(schedule -> scheduleMemberRepository.findByMemberIdAndScheduleId(member.getId(), schedule.getId()).isEmpty())
                 .map(schedule -> new ScheduleMember(schedule, member))
                 .toList();
         scheduleMemberRepository.saveAll(scheduleMembers);


### PR DESCRIPTION
# 관련 이슈
FD-367

# 변경된 점
- 알림에 읽은 시간 추가
- 미확인 알림 생성 로직 변경
  - 24시간 동안 읽지 않은 '피드백 도착 알림' 존재 시 '미확인 알림' 생성 시도
    - 해당 사용자에게 존재하는 가장 최신의 '미확인 알림' 을 확인
      - 해당 알림이 읽지 않은 상태인 경우 생성하지 않음
      - 해당 알림이 읽은 상태이지만, 읽은 시간이 24시간 이내라면 생성하지 않음
    - 이외의 경우 생성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - In-app notifications now include a read timestamp, ensuring more accurate status tracking.
  - Enhanced notification retrieval allows displaying multiple notifications based on specific criteria.

- **Refactor**
  - Streamlined logic for marking notifications as read boosts responsiveness, including cascading updates for related items.
  - Improved schedule management prevents duplicate member entries, offering a smoother experience.

- **Tests**
  - Expanded test scenarios ensure reliable notification handling and time-based behavior under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->