### PR TITLE
[FD-372] 알림 눌렀을때 동작 처리

### DIFF
--- a/front-end/public/service-worker.js
+++ b/front-end/public/service-worker.js
@@ -48,7 +48,10 @@ self.addEventListener('push', function (event) {
       notificationBody = '팀장이 되었어요! 팀을 이끌 준비가 되셨나요?';
       break;
     case 'scheduleCreate':
-      clickUrl = `/`;
+      clickUrl = `/calendar`;
+      parameter = {
+        scheduleDate: notification.scheduleDate,
+      };
       notificationBody = '새로운 일정이 추가되었어요!';
       break;
     case 'regularFeedbackRequest':
@@ -84,7 +87,7 @@ self.addEventListener('notificationclick', function (event) {
     queryParameter += `&${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
   });
 
-  const url = new URL(queryParameter, self.location.origin).href;
+  const url = new URL(queryParameter, self.location.origin + '/main').href;
   notification.close();
   console.log(url);
   event.waitUntil(self.clients.openWindow(url));

--- a/front-end/src/api/useMainPage.js
+++ b/front-end/src/api/useMainPage.js
@@ -46,6 +46,7 @@ export const useNotification = (teamId) => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ['notification', teamId],
     queryFn: () => api.get({ url: '/api/notification' }),
+    gcTime: 0,
     enabled: !!teamId,
   });
 

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -23,7 +23,7 @@ export default function Calendar() {
 
   // 날짜 지정
   const [selectedDate, setSelectedDate] = useState(
-    location.state?.initialDate ?? new Date(new Date().setHours(0, 0, 0, 0)),
+    location.state?.scheduleDate ?? new Date(new Date().setHours(0, 0, 0, 0)),
   );
 
   // 일정 조회 관련

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -31,6 +31,15 @@ import Banner from './components/Banner';
 
 export default function MainPage() {
   const location = useLocation();
+  console.log(location.search);
+  const searchParams = new URLSearchParams(location.search);
+  const redirect = searchParams.get('redirect') ?? null;
+  const teamId = searchParams.get('teamId') ?? null;
+  const senderId = searchParams.get('senderId') ?? null;
+  const scheduleId = searchParams.get('scheduleId') ?? null;
+  const scheduleDate = searchParams.get('scheduleDate') ?? null;
+
+  const navigate = useNavigate();
   const [banners, setBanners] = useState();
   const [timeDiff, setTimeDiff] = useState();
   const [isTodoAddOpen, toggleTodoAdd] = useReducer((prev) => !prev, false);
@@ -49,11 +58,25 @@ export default function MainPage() {
     selectedDate,
     recentScheduleData,
   );
-  const navigate = useNavigate();
 
   // TODO: 로딩 중 혹은 에러 발생 시 처리
 
   useBlockPop(location.pathname);
+
+  useEffect(() => {
+    let state = {};
+    if (redirect) {
+      navigate('/main', { replace: true });
+      if (teamId) {
+        state = { teamId, senderId };
+      } else if (scheduleId) {
+        state = { scheduleId };
+      } else if (scheduleDate) {
+        state = { scheduleDate };
+      }
+      navigate(redirect, { state });
+    }
+  }, []);
 
   useEffect(() => {
     clearData();

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -31,7 +31,6 @@ import Banner from './components/Banner';
 
 export default function MainPage() {
   const location = useLocation();
-  console.log(location.search);
   const searchParams = new URLSearchParams(location.search);
   const redirect = searchParams.get('redirect') ?? null;
   const teamId = searchParams.get('teamId') ?? null;

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -67,9 +67,9 @@ export default function MainPage() {
     if (redirect) {
       navigate('/main', { replace: true });
       if (teamId) {
-        state = { teamId, senderId };
+        state = { teamId, senderId, isRegular: false };
       } else if (scheduleId) {
-        state = { scheduleId };
+        state = { scheduleId, isRegular: true };
       } else if (scheduleDate) {
         state = { scheduleDate };
       }

--- a/front-end/src/pages/main/components/Alarm.jsx
+++ b/front-end/src/pages/main/components/Alarm.jsx
@@ -26,20 +26,31 @@ export default function Alarm({ type, data }) {
 
   return (
     <button
-      className='w-full text-start'
+      className={`rounded-300 w-full text-start ${data.read || 'bg-gray-700'}`}
       onClick={() => handleFunction(navigate, data)}
     >
-      <div className='flex w-full gap-5 border-b border-b-gray-800 py-4'>
-        <div className='flex aspect-square h-10 w-10 items-center justify-center rounded-full bg-gray-800 p-2'>
+      <div className='flex w-full border-b border-b-gray-800 py-4'>
+        <div className='mx-4 flex aspect-square h-10 w-10 items-center justify-center rounded-full bg-gray-800 p-2.5'>
           <img src={image} alt={imageAlt} width={28} height={28} />
         </div>
-        <div className='caption-1 flex flex-col gap-1.5 text-gray-400'>
+        <div className='caption-1 flex flex-1 flex-col gap-1.5 pr-4 text-gray-400'>
           <div className='flex flex-col gap-1'>
-            <p className='body-2 text-gray-100'>{title}</p>
+            <div className='flex justify-between'>
+              <p className='body-2 text-gray-100'>{title}</p>
+              {/* {data.read || (
+                <div className='size-2 self-start rounded-full bg-lime-500 px-1'></div>
+              )} */}
+            </div>
             <p className='whitespace-pre-line text-gray-100'>{content}</p>
           </div>
-          {calTimePassed(data.createdAt)}
+          <div className='flex'>
+            {calTimePassed(data.createdAt)}
+            {data.read || (
+              <div className='mx-2 size-[5px] shrink-0 self-center rounded-full bg-lime-500'></div>
+            )}
+          </div>
         </div>
+        {/* {data.read || <div className='self-center px-3 text-lime-500'>•</div>} */}
       </div>
     </button>
   );
@@ -56,7 +67,7 @@ const filterDataWithType = ({ data, type }) => {
     // data.senderName, data.teamName
     case alarmType.FEEDBACK_RECEIVED:
       title = '새로운 피드백이 도착했어요';
-      content = `${data.senderName}님(${data.teamName})이 피드백을 보냈어요.`;
+      content = `${data.senderName}님(${data.teamName})이 피드백을 보냈어요`;
       image = '/src/assets/images/mail-received.png';
       imageAlt = 'mail';
       handleFunction = (navigate) => handleFeedbackReceived(navigate);
@@ -64,7 +75,7 @@ const filterDataWithType = ({ data, type }) => {
     // data.senderName, data.teamName
     case alarmType.HEART_RECEIVED:
       title = '내가 보낸 피드백이 도움됐어요';
-      content = `${data.senderName}님(${data.teamName})이 내가 보낸 피드백에 공감을 눌렀어요.`;
+      content = `${data.senderName}님(${data.teamName})이 내가 보낸 피드백에 공감을 눌렀어요`;
       image = '/src/assets/images/heart-green.png';
       imageAlt = 'heart';
       handleFunction = (navigate) => handleFeedbackReceived(navigate);
@@ -72,7 +83,7 @@ const filterDataWithType = ({ data, type }) => {
     // data.senderName
     case alarmType.FREQUENT_FEEDBACK_REQUESTED:
       title = `${data.senderName} 님이 피드백을 요청했어요`;
-      content = `요청받은 내용을 확인하고 피드백을 보내주세요.`;
+      content = `요청받은 내용을 확인하고 피드백을 보내주세요`;
       image = '/src/assets/images/pray.png';
       imageAlt = 'pray';
       handleFunction = (navigate, data) =>
@@ -82,7 +93,7 @@ const filterDataWithType = ({ data, type }) => {
     case alarmType.REPORT_RECEIVED:
       title = '피드백 리포트가 도착했어요';
       content = `${data.teamName} 프로젝트 잘 마무리 하셨나요?
-      ${data.receiverName} 님이 받은 피드백을 정리했어요.`;
+      ${data.receiverName} 님이 받은 피드백을 정리했어요`;
       image = '/src/assets/images/folder.png';
       imageAlt = 'folder';
       handleFunction = (navigate) => handleReportCreate(navigate);
@@ -90,7 +101,7 @@ const filterDataWithType = ({ data, type }) => {
     // data.senderName, data.teamName
     case alarmType.NEED_CHECK_FEEDBACK:
       title = '확인하지 않은 피드백이 있어요';
-      content = `${data.senderName}님(${data.teamName})이 보낸 피드백을 확인해 주세요.`;
+      content = `${data.senderName}님(${data.teamName})이 보낸 피드백을 확인해 주세요`;
       image = '/src/assets/images/check-bg-black.png';
       imageAlt = 'check';
       handleFunction = (navigate) => handleFeedbackReceived(navigate);
@@ -107,7 +118,7 @@ const filterDataWithType = ({ data, type }) => {
     // data.teamName
     case alarmType.SCHEDULE_ADDED:
       title = `${data.teamName}의 새로운 일정이 추가됐어요`;
-      content = `추가된 일정을 확인하고 나의 역할을 추가해 주세요.`;
+      content = `추가된 일정을 확인하고 나의 역할을 추가해 주세요`;
       image = '/src/assets/images/calendar.png';
       imageAlt = 'calendar';
       handleFunction = (navigate) => handleGoMain(navigate);
@@ -115,7 +126,7 @@ const filterDataWithType = ({ data, type }) => {
     // data.scheduleName
     case alarmType.REGULAR_FEEDBACK_REQUESTED:
       title = '피드백을 작성해주세요';
-      content = `${data.scheduleName} 피드백을 작성해주세요.`;
+      content = `${data.scheduleName} 피드백을 작성해주세요`;
       image = '/src/assets/images/pencil.png';
       imageAlt = 'write';
       handleFunction = (navigate, data) => handleRegFeedbackReq(navigate, data);

--- a/front-end/src/pages/main/components/Alarm.jsx
+++ b/front-end/src/pages/main/components/Alarm.jsx
@@ -78,7 +78,7 @@ const filterDataWithType = ({ data, type }) => {
       content = `${data.senderName}님(${data.teamName})이 내가 보낸 피드백에 공감을 눌렀어요`;
       image = '/src/assets/images/heart-green.png';
       imageAlt = 'heart';
-      handleFunction = (navigate) => handleFeedbackReceived(navigate);
+      handleFunction = (navigate) => handleHeartReaction(navigate);
       break;
     // data.senderName
     case alarmType.FREQUENT_FEEDBACK_REQUESTED:


### PR DESCRIPTION
알림 눌렀을때 동작 수정했습니다
- 알림함 알림 누르기 전 후 상태 변경 (누르기 전에 배경 밝은 회색 + 시간 옆에 초록 점)
- 푸시 알림 눌렀을때 해당하는 페이지로 이동
   - 리다이렉트 경로와 필요한 상태들 담아서 푸시알림 생성 
   - 알림 눌렀을때 우선 메인페이지로 이동
   - 메인페이지에서 알림에 담겨있던 리다이렉트 경로와 상태 파싱
   - 현재 경로에서 쿼리파라미터 삭제 (/main?key=value --> /main)
   - 리다이렉트 경로로 state 설정해서 navigate
- 하트 받은 알림 누르면 보낸 피드백으로 가도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced push notifications now direct schedule alerts to the calendar with updated event details.
  - Improved main view navigation enables smoother redirection based on URL parameters.
  - The calendar now initializes using the scheduled event date for a more accurate display.

- **Style**
  - Alarm notifications feature refined layouts and visual indicators for unread messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->