### PR TITLE
[FD-386] 수시 피드백 전송 시 연관 요청 삭제되도록 수정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/service/FeedbackService.java
@@ -209,14 +209,14 @@ public class FeedbackService {
         Feedback feedback = feedbackRepository
                 .findById(feedbackId).orElseThrow(() -> new EntityNotFoundException("feedback id에 해당하는 feedback이 없습니다."));
 
-        Member receiver = memberRepository.findById(feedback.getReceiver().getId())
+        Member feedbackReceiver = memberRepository.findById(feedback.getReceiver().getId())
                 .orElseThrow();
-        Member sender = memberRepository.findById(feedback.getSender().getId())
+        Member feedbackSender = memberRepository.findById(feedback.getSender().getId())
                 .orElseThrow();
         Team team = teamRepository.findById(feedback.getTeam().getId())
                 .orElseThrow();
 
-        team.removeFeedbackRequest(sender, receiver);
+        team.removeFeedbackRequest(feedbackReceiver, feedbackSender);
 
     }
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -110,24 +110,24 @@ public class Team {
     }
 
     // 수시 피드백 요청
-    public void requestFeedback(Member sender, Member receiver, String requestedContent) {
-        validateTeamMember(sender);
-        validateTeamMember(receiver);
-        this.frequentFeedbackRequests.removeIf(request -> sender.equals(request.getSender()) && receiver.equals(request.getReceiver()));
-        this.frequentFeedbackRequests.add(new FrequentFeedbackRequest(requestedContent, sender, this, receiver));
+    public void requestFeedback(Member requestSender, Member requestReceiver, String requestedContent) {
+        validateTeamMember(requestSender);
+        validateTeamMember(requestReceiver);
+        this.frequentFeedbackRequests.removeIf(request -> requestSender.equals(request.getSender()) && requestReceiver.equals(request.getReceiver()));
+        this.frequentFeedbackRequests.add(new FrequentFeedbackRequest(requestedContent, requestSender, this, requestReceiver));
     }
 
     // 모든 수시 피드백 요청 거절
-    public void rejectFeedbackRequests(Member receiver) {
-        validateTeamMember(receiver);
-        this.frequentFeedbackRequests.removeIf(request -> receiver.equals(request.getReceiver()));
+    public void rejectFeedbackRequests(Member requestReceiver) {
+        validateTeamMember(requestReceiver);
+        this.frequentFeedbackRequests.removeIf(request -> requestReceiver.equals(request.getReceiver()));
     }
 
     // 특정 수시 피드백 요청 거절
-    public void removeFeedbackRequest(Member sender, Member receiver) {
-        validateTeamMember(sender);
-        validateTeamMember(receiver);
-        this.frequentFeedbackRequests.removeIf(request -> sender.equals(request.getSender()) && receiver.equals(request.getReceiver()));
+    public void removeFeedbackRequest(Member requestSender, Member requestReceiver) {
+        validateTeamMember(requestSender);
+        validateTeamMember(requestReceiver);
+        this.frequentFeedbackRequests.removeIf(request -> requestSender.equals(request.getSender()) && requestReceiver.equals(request.getReceiver()));
     }
 
     public List<FrequentFeedbackRequest> getFeedbackRequests(Member receiver) {

--- a/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/feedback/service/FeedbackServiceTest.java
@@ -911,24 +911,25 @@ class FeedbackServiceTest {
         @DisplayName("연관 수시 피드백 요청 삭제 성공")
         void test1() {
             // given
-            Member sender = createMember("sender");
-            Member receiver = createMember("receiver");
-            Team team = createTeam("team", sender);
-            team.join(receiver);
-            team.requestFeedback(sender, receiver, "좋아요");
+            Member feedbackSender = createMember("sender");
+            Member feedbackReceiver = createMember("receiver");
+            Team team = createTeam("team", feedbackSender);
+            team.join(feedbackReceiver);
+            team.requestFeedback(feedbackSender, feedbackReceiver, "좋아요");
+            team.requestFeedback(feedbackReceiver, feedbackSender, "좋아요 2");
 
-            Feedback feedback = createFeedback(sender, receiver, team);
+            Feedback feedback = createFeedback(feedbackSender, feedbackReceiver, team);
 
             when(feedbackRepository.findById(feedback.getId())).thenReturn(Optional.of(feedback));
-            when(memberRepository.findById(sender.getId())).thenReturn(Optional.of(sender));
-            when(memberRepository.findById(receiver.getId())).thenReturn(Optional.of(receiver));
+            when(memberRepository.findById(feedbackSender.getId())).thenReturn(Optional.of(feedbackSender));
+            when(memberRepository.findById(feedbackReceiver.getId())).thenReturn(Optional.of(feedbackReceiver));
             when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
 
             // when
             feedbackService.deleteRelatedFrequentFeedbackRequest(feedback.getId());
 
             // then
-            assertThat(team.getFeedbackRequests(receiver)).isEmpty();
+            assertThat(team.getFeedbackRequests(feedbackSender)).isEmpty();
         }
 
 


### PR DESCRIPTION
# 관련 이슈
FD-386

# 변경된 점
- 수시 피드백 전송 시 연관된 수시 피드백 요청이 삭제되도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the clarity and consistency of operations related to feedback management and team interactions.
- **Tests**
  - Updated test scenarios to ensure the continued robustness and reliability of feedback processes.

These internal enhancements maintain seamless functionality while supporting long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->