### PR TITLE
[FD-385] 일정 페이지 디버깅

### DIFF
--- a/front-end/src/api/useCalendar.js
+++ b/front-end/src/api/useCalendar.js
@@ -1,4 +1,6 @@
+import useSchedule from '../pages/calendar/hooks/useSchedule';
 import { showToast } from '../utility/handleToast';
+import { getRecentSunday, toKST } from '../utility/time';
 import { api } from './baseApi';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -72,15 +74,20 @@ export const useEditSchedule = (teamId) => {
   });
 };
 
-export const useDeleteSchedule = (teamId) => {
+export const useDeleteSchedule = ({ teamId, scheduleStartTime }) => {
   const queryClient = useQueryClient();
+  const recentSunday = toKST(getRecentSunday(scheduleStartTime))
+    .toISOString()
+    .split('T')[0];
   return useMutation({
-    mutationFn: (scheduleId) =>
-      api.delete({
+    mutationFn: (scheduleId) => {
+      id = scheduleId;
+      return api.delete({
         url: `/api/team/${teamId}/schedule/${scheduleId}`,
-      }),
+      });
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['schedules'] });
+      queryClient.invalidateQueries({ queryKey: ['schedules', recentSunday] });
     },
   });
 };

--- a/front-end/src/api/useCalendar.js
+++ b/front-end/src/api/useCalendar.js
@@ -80,12 +80,11 @@ export const useDeleteSchedule = ({ teamId, scheduleStartTime }) => {
     .toISOString()
     .split('T')[0];
   return useMutation({
-    mutationFn: (scheduleId) => {
-      id = scheduleId;
-      return api.delete({
+    mutationFn: (scheduleId) =>
+      api.delete({
         url: `/api/team/${teamId}/schedule/${scheduleId}`,
-      });
-    },
+      }),
+
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['schedules', recentSunday] });
     },

--- a/front-end/src/components/Dropdown.jsx
+++ b/front-end/src/components/Dropdown.jsx
@@ -47,32 +47,20 @@ export function DropdownLarge({
   const detailsRef = useRef(null);
   const selectedItemRef = useRef(null);
 
-  useEffect(() => {
+  // details 태그가 열릴 때마다 선택한 항목으로 스크롤 이동
+  const handleToggle = () => {
     if (selectedItemRef.current) {
-      const dropdown = detailsRef.current;
       const selectedItem = selectedItemRef.current;
 
-      const dropdownHeight = dropdown.getBoundingClientRect().height;
-      const itemHeight = selectedItem.getBoundingClientRect().height;
-
-      const scrollTo =
-        selectedItem.offsetTop - dropdownHeight / 2 + itemHeight / 2;
-      dropdown.animate({ scrollTop: scrollTo }, { duration: 300 });
-    }
-  }, []);
-
-  // 선택된 항목이 바뀌면 해당 항목이 보이도록 스크롤 이동
-  useEffect(() => {
-    if (detailsRef.current.open && selectedItemRef.current) {
-      selectedItemRef.current.scrollIntoView({
+      selectedItem.scrollIntoView({
         behavior: 'smooth',
-        block: 'nearest',
+        block: 'center',
       });
     }
-  }, [triggerText]);
+  };
 
   return (
-    <details ref={detailsRef} className='group flex-1'>
+    <details ref={detailsRef} onToggle={handleToggle} className='group flex-1'>
       <summary
         className={`${isTransparent ? 'border border-gray-300' : 'bg-gray-700'} rounded-200 body-1 flex size-fit w-full cursor-pointer list-none items-center justify-between px-5 py-3.5 whitespace-pre text-gray-200`}
       >
@@ -88,22 +76,19 @@ export function DropdownLarge({
         {itemsComponent ?
           itemsComponent
         : <ul className='rounded-200 flex max-h-56 w-[120px] flex-col gap-1 overflow-y-auto bg-gray-700 p-2'>
-            {
-              //TODO: 시간대 배열
-              items.map((item, index) => (
-                <li
-                  key={index}
-                  ref={item === triggerText ? selectedItemRef : null}
-                  onClick={() => {
-                    detailsRef.current.open = false;
-                    setTriggerText(item);
-                  }}
-                  className={`body-1 cursor-pointer list-none px-2.5 py-2 text-center ${item === triggerText ? 'text-lime-500' : 'text-gray-0'}`}
-                >
-                  {item}
-                </li>
-              ))
-            }
+            {items.map((item, index) => (
+              <li
+                key={index}
+                ref={item === triggerText ? selectedItemRef : null}
+                onClick={() => {
+                  detailsRef.current.open = false;
+                  setTriggerText(item);
+                }}
+                className={`body-1 cursor-pointer list-none px-2.5 py-2 text-center ${item === triggerText ? 'text-lime-500' : 'text-gray-0'}`}
+              >
+                {item}
+              </li>
+            ))}
           </ul>
         }
       </div>

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -125,6 +125,7 @@ export default function Calendar() {
           onClose={() => setDoingAction(false)}
           actionInfo={actionInfo}
           dateFixed={actionType === ScheduleActionType.ADD}
+          setAllSchedules={setAllSchedules}
           setParentDate={setSelectedDate}
         />
       )}

--- a/front-end/src/pages/calendar/components/CalendarParts.jsx
+++ b/front-end/src/pages/calendar/components/CalendarParts.jsx
@@ -66,16 +66,15 @@ export function CalendarWeek({
   scheduleSet,
   setAllSchedules,
 }) {
-  const { selectedTeam, teams } = useTeam();
+  const dateList = getDateList(curSunday);
+
   const {
     data: schedules,
     isLoading: isSchedulesLoading,
     refetch,
   } = useGetSchedules({
-    startDay: new Date(curSunday).toISOString().split('T')[0],
-    endDay: new Date(new Date().setDate(new Date(curSunday).getDate() + 7))
-      .toISOString()
-      .split('T')[0],
+    startDay: toKST(dateList[0]).toISOString().split('T')[0],
+    endDay: toKST(dateList[6]).toISOString().split('T')[0],
   });
 
   useEffect(() => {
@@ -83,7 +82,6 @@ export function CalendarWeek({
     setAllSchedules((prev) => removeDuplicate([...prev, ...schedules]));
   }, [schedules, isSchedulesLoading]);
 
-  const dateList = getDateList(curSunday);
   return (
     <div className='min-w-full'>
       <div className='grid w-full grid-cols-7 gap-4'>

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -14,7 +14,7 @@ import { showToast } from '../../../utility/handleToast';
 import { checkNewSchedule, isEmpty } from '../../../utility/inputChecker';
 import TimeSelector from './TimeSelector';
 import Todo from './Todo';
-import { showModal } from '../../../utility/handleModal';
+import { hideModal, showModal } from '../../../utility/handleModal';
 import ScheduleDeleteModal from './ScheduleDeleteModal';
 import CustomDatePicker, {
   DatePickerButton,
@@ -53,6 +53,7 @@ export default function ScheduleAction({
   selectedDateFromParent,
   actionInfo,
   dateFixed,
+  setAllSchedules,
   setParentDate = () => {},
 }) {
   const { selectedTeam } = useTeam();
@@ -137,6 +138,13 @@ export default function ScheduleAction({
         deleteSchedule={() => {
           deleteSchedule(selectedScheduleFromParent.scheduleId ?? -1, {
             onSuccess: () => {
+              setAllSchedules((prev) => [
+                ...prev.filter(
+                  (schedule) =>
+                    schedule.scheduleId !==
+                    selectedScheduleFromParent.scheduleId,
+                ),
+              ]);
               showToast('일정을 삭제했습니다');
               onClose();
             },

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -64,7 +64,10 @@ export default function ScheduleAction({
 
   const { mutate: postSchedule } = usePostSchedule(selectedTeam);
   const { mutate: editSchedule } = useEditSchedule(selectedTeam);
-  const { mutate: deleteSchedule } = useDeleteSchedule(selectedTeam);
+  const { mutate: deleteSchedule } = useDeleteSchedule({
+    teamId: selectedTeam,
+    scheduleStartTime: actionInfo.startTime,
+  });
   const [dataReady, setDataReady] = useState(false);
 
   useEffect(() => {
@@ -135,7 +138,6 @@ export default function ScheduleAction({
           deleteSchedule(selectedScheduleFromParent.scheduleId ?? -1, {
             onSuccess: () => {
               showToast('일정을 삭제했습니다');
-              hideModal();
               onClose();
             },
           });

--- a/front-end/src/pages/calendar/components/ScheduleCard.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleCard.jsx
@@ -67,7 +67,7 @@ export default function ScheduleCard({
       </div>
       <hr className='w-full border-gray-500' />
       {/* 나의 역할 */}
-      {myRole ?
+      {myRole.length > 0 ?
         <div className='flex flex-col gap-3'>
           <Tag type={TagType.MY_ROLE}></Tag>
           <div className='flex flex-col gap-1'>
@@ -107,7 +107,7 @@ export default function ScheduleCard({
             );
           })
         : <div className='body-1 text-center text-gray-500'>
-            팀원들이 아직 입력하지 않았어요
+            표시할 팀원이 없어요
           </div>
         }
       </div>

--- a/front-end/src/pages/calendar/components/ScheduleDeleteModal.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleDeleteModal.jsx
@@ -22,6 +22,7 @@ export default function ScheduleDeleteModal({ deleteSchedule, onClose }) {
           isOutlined={false}
           onClick={() => {
             deleteSchedule();
+            hideModal();
             onClose();
           }}
         />

--- a/front-end/src/pages/calendar/components/ScheduleDeleteModal.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleDeleteModal.jsx
@@ -21,8 +21,8 @@ export default function ScheduleDeleteModal({ deleteSchedule, onClose }) {
           text='삭제'
           isOutlined={false}
           onClick={() => {
-            deleteSchedule();
             hideModal();
+            deleteSchedule();
             onClose();
           }}
         />

--- a/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
+++ b/front-end/src/pages/calendar/hooks/useScheduleAction.jsx
@@ -1,11 +1,20 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ScheduleActionType } from '../components/ScheduleAction';
 import { useUser } from '../../../useUser';
+import { getNearest10MinTime } from '../../../utility/time';
 
 export default function useScheduleAction(date, selectedSchedule) {
   const { userId } = useUser();
   const [doingAction, setDoingAction] = useState(false);
   const [actionType, setActionType] = useState(ScheduleActionType.ADD);
+
+  const { curHour, curMinute } = useMemo(() => {
+    const nearestTime = getNearest10MinTime(new Date());
+    return {
+      curHour: nearestTime.getHours(),
+      curMinute: nearestTime.getMinutes(),
+    };
+  }, []);
 
   const [selectedDate, setSelectedDate] = useState(new Date(date));
   const [scheduleName, setScheduleName] = useState(
@@ -13,11 +22,15 @@ export default function useScheduleAction(date, selectedSchedule) {
   );
   const [startTime, setStartTime] = useState(
     new Date(
-      selectedSchedule?.startTime ?? new Date(date).setHours(12, 0, 0, 0),
+      selectedSchedule?.startTime ??
+        new Date(date).setHours(curHour, curMinute),
     ),
   );
   const [endTime, setEndTime] = useState(
-    new Date(selectedSchedule?.endTime ?? new Date(date).setHours(12, 0, 0, 0)),
+    new Date(
+      selectedSchedule?.endTime ??
+        new Date(date).setHours(curHour, curMinute + 10),
+    ),
   );
   const [todos, setTodo] = useState(
     selectedSchedule?.scheduleMemberNestedDtoList?.find(
@@ -27,8 +40,10 @@ export default function useScheduleAction(date, selectedSchedule) {
 
   const clearData = () => {
     setScheduleName('');
-    setStartTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
-    setEndTime(new Date(new Date(selectedDate).setHours(12, 0, 0, 0)));
+    setStartTime(new Date(new Date(selectedDate).setHours(curHour, curMinute)));
+    setEndTime(
+      new Date(new Date(selectedDate).setHours(curHour, curMinute + 10)),
+    );
     setTodo([]);
   };
 
@@ -38,12 +53,14 @@ export default function useScheduleAction(date, selectedSchedule) {
     setScheduleName(selectedSchedule?.scheduleName ?? '');
     setStartTime(
       new Date(
-        selectedSchedule?.startTime ?? new Date(date).setHours(12, 0, 0, 0),
+        selectedSchedule?.startTime ??
+          new Date(date).setHours(curHour, curMinute),
       ),
     );
     setEndTime(
       new Date(
-        selectedSchedule?.endTime ?? new Date(date).setHours(12, 0, 0, 0),
+        selectedSchedule?.endTime ??
+          new Date(date).setHours(curHour, curMinute + 10),
       ),
     );
     const newTodos =

--- a/front-end/src/utility/time.js
+++ b/front-end/src/utility/time.js
@@ -140,6 +140,11 @@ export function timePickerToDate(date, time) {
   );
 }
 
+/**
+ * 년-월-일 문자열 반환
+ * @param {Date} date - 날짜
+ * @returns {string}
+ */
 export function toYMD(date) {
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, '0');
@@ -148,6 +153,12 @@ export function toYMD(date) {
   return formattedDate;
 }
 
+/**
+ *  date1의 날짜와 date2의 시간을 가진 Date객체 반환
+ * @param {Date} date1
+ * @param {Date} date2
+ * @returns {Date}
+ */
 export function combineDateTime(date1, date2) {
   const year = date1.getFullYear();
   const month = date1.getMonth();
@@ -159,6 +170,11 @@ export function combineDateTime(date1, date2) {
   return new Date(year, month, day, hours, minutes);
 }
 
+/**
+ * 표준시간 표기를 한국시간으로 변환해서 반환
+ * @param {String | Date} date
+ * @returns {Date}
+ */
 export function toKST(date) {
   let kst = new Date(date);
   kst.setTime(new Date(date).getTime() + 1000 * 60 * 60 * 9);
@@ -187,4 +203,22 @@ export function getScheduleTimeDiff(recentSchedule) {
     // 과거 일정인 경우
     return Math.ceil((endTime - todayTime) / (1000 * 60 * 60 * 24));
   }
+}
+
+/**
+ * 현재 시간과 제일 가까운 미래의 10분단위의 시간 반환
+ * @param {Date} currentTime - 현재 시간
+ * @returns {date}
+ */
+export function getNearest10MinTime(currentTime) {
+  const result = new Date(currentTime);
+
+  result.setSeconds(0, 0);
+
+  const minutes = result.getMinutes();
+  const remainder = minutes % 10;
+
+  const diff = remainder === 0 ? 10 : 10 - remainder;
+  result.setMinutes(minutes + diff);
+  return result;
 }


### PR DESCRIPTION
일정 페이지에 있던 각종 버그 사항들 디버깅 했습니다.
- 내 역할 없을때 화면 수정
- 일정 불러오는 API에 전달되던 기간 수정
   - <토, 일, 월, 화, 수, 목, 금, 토, 일> 까지 9일간의 일정 요청했던 부분이 <일, 월, 화, 수, 목, 금, 토>로 7일간의 일정을 요청하도록 수정됨
   - 월 말 ~ 월 초 조회시 시작 날짜와 종료 날짜 반대로 전달되어 오류 나던 부분 디버깅 (ex. 2월 23일 ~ 3월 1일 주간 조회시, 요청이 3월 1일 ~ 2월 23일로 가서 에러났었음)
- 일정 삭제 했을때 화면에 바로 반영되도록 수정

<img width="430" alt="스크린샷 2025-02-19 오전 10 35 38" src="https://github.com/user-attachments/assets/b06c7b2a-ac11-425c-880a-f1aceb870129" />

<img width="387" alt="스크린샷 2025-02-19 오전 10 35 11" src="https://github.com/user-attachments/assets/b7b1895f-3cc0-40d3-9ad3-4a7789a81283" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced schedule management: Deleting a schedule now updates the calendar view immediately with more precise date handling.
  - Improved dropdown behavior: Dropdowns now toggle with smooth, centered scrolling for a better navigation experience.
  - Updated calendar display: Weekly schedules and team member roles are now presented more clearly, with refined messages when no team members are available.
  - Better time management: Scheduling times are now aligned to the nearest 10-minute interval and automatically adjusted to local time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->