### PR TITLE
[FD-388]  팀 정보 수정과 일정 생성 간 동시성 문제 해결

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/controller/ScheduleController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/controller/ScheduleController.java
@@ -6,6 +6,7 @@ import com.feedhanjum.back_end.schedule.controller.dto.ScheduleRequest;
 import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleNestedDto;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
+import com.feedhanjum.back_end.teamplanorchestration.service.TeamPlanOrchestrationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -23,6 +24,7 @@ import java.util.List;
 @RequestMapping("/api")
 public class ScheduleController {
     private final ScheduleService scheduleService;
+    private final TeamPlanOrchestrationService teamPlanOrchestrationService;
 
     @Operation(summary = "새 일정 만들기", description = "해당 팀의 새로운 일정을 만듭니다.")
     @ApiResponses({
@@ -34,7 +36,7 @@ public class ScheduleController {
     })
     @PostMapping("/team/{teamId}/schedule/create")
     public ResponseEntity<Void> createSchedule(@Login Long memberId, @PathVariable Long teamId, @Valid @RequestBody ScheduleRequest request) {
-        scheduleService.createSchedule(memberId, teamId, new ScheduleRequestDto(request));
+        teamPlanOrchestrationService.createSchedule(memberId, teamId, new ScheduleRequestDto(request));
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
@@ -49,7 +51,7 @@ public class ScheduleController {
                                                @PathVariable Long teamId, 
                                                @PathVariable Long scheduleId, 
                                                @Valid @RequestBody ScheduleRequest request) {
-        scheduleService.updateSchedule(memberId, teamId, scheduleId, new ScheduleRequestDto(request));
+        teamPlanOrchestrationService.updateSchedule(memberId, teamId, scheduleId, new ScheduleRequestDto(request));
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/schedule/service/ScheduleService.java
@@ -9,18 +9,14 @@ import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
 import com.feedhanjum.back_end.schedule.domain.Schedule;
 import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
-import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
 import com.feedhanjum.back_end.schedule.event.ScheduleEndedEvent;
-import com.feedhanjum.back_end.schedule.exception.ScheduleAlreadyExistException;
 import com.feedhanjum.back_end.schedule.exception.ScheduleIsAlreadyEndException;
-import com.feedhanjum.back_end.schedule.exception.ScheduleMembershipNotFoundException;
 import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleQueryRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleRepository;
 import com.feedhanjum.back_end.schedule.repository.dto.ScheduleProjectionDto;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleMemberNestedDto;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleNestedDto;
-import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
 import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
@@ -28,7 +24,6 @@ import com.feedhanjum.back_end.team.repository.TeamRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
@@ -56,57 +51,9 @@ public class ScheduleService {
     private final EventPublisher eventPublisher;
     private final RegularFeedbackRequestQueryRepository regularFeedbackRequestQueryRepository;
 
-    /**
-     * 일정을 생성하는 메소드
-     *
-     * @throws EntityNotFoundException         사용자 혹은 팀이 존재하지 않는 경우
-     * @throws TeamMembershipNotFoundException 해당 사용자가 팀에 가입한 상태가 아닌경우
-     * @throws ScheduleAlreadyExistException   해당 일정의 시작 시간에 일정이 존재하는 경우
-     * @throws RuntimeException                내부 서버 오류: 방금 조회한 사용자 ID가 사라짐
-     */
-    @Transactional
-    public void createSchedule(Long memberId, Long teamId, ScheduleRequestDto requestDto) {
-        Team team = teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
-        teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).orElseThrow(() -> new TeamMembershipNotFoundException("해당 팀에 존재하는 사람만 일정을 생성할 수 있습니다."));
 
-        validateScheduleDuplicate(teamId, requestDto);
-        validateScheduleTimeIntoTeamTime(requestDto, team);
-        validateEndTimeIsAfterNow(requestDto.endTime());
 
-        Schedule schedule = scheduleRepository.save(
-                new Schedule(
-                        requestDto.name(),
-                        requestDto.startTime(),
-                        requestDto.endTime(),
-                        team,
-                        member));
 
-        memberQueryRepository.findMembersByTeamId(teamId).forEach(m -> scheduleMemberRepository.save(new ScheduleMember(schedule, m)));
-        ScheduleMember scheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, schedule.getId()).orElseThrow(() -> new RuntimeException("내부 서버 에러: 방금 조회한 사용자 ID가 사라짐"));
-        scheduleMember.setTodos(requestDto.todos());
-        eventPublisher.publishEvent(new ScheduleCreatedEvent(schedule.getId()));
-    }
-
-    /**
-     * @throws SecurityException                   일정 내용을 수정하려는 사람이 팀장, 일정의 주인이 아닌 경우
-     * @throws EntityNotFoundException             팀, 사용자 또는 일정을 찾을 수 없는 경우
-     * @throws ScheduleMembershipNotFoundException 회원이 해당 일정과 연관이 없을 경우
-     * @throws IllegalArgumentException            일정의 시간 설정이 잘못된 경우
-     */
-
-    @Transactional(isolation = Isolation.REPEATABLE_READ)
-    public void updateSchedule(Long memberId, Long teamId, Long scheduleId, ScheduleRequestDto requestDto) {
-        Team team = teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
-        Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new EntityNotFoundException("해당 일정을 찾을 수 없습니다."));
-        validateIsEnded(schedule);
-        ScheduleMember scheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, scheduleId)
-                .orElseThrow(() -> new ScheduleMembershipNotFoundException("해당 일정을 찾을 수 없습니다."));
-
-        changeScheduleInfo(requestDto, schedule, member, team);
-        scheduleMember.setTodos(requestDto.todos());
-    }
 
     @Transactional(readOnly = true)
     public ScheduleNestedDto getSchedule(Long memberId, Long teamId, Long scheduleId) {
@@ -279,63 +226,5 @@ public class ScheduleService {
         teamRepository.findById(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
         teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).orElseThrow(() -> new TeamMembershipNotFoundException("해당 팀에 속해있지 않습니다."));
-    }
-
-    private void validateIsEnded(Schedule schedule) {
-        if (schedule.getEndTime().isBefore(LocalDateTime.now(clock))) {
-            throw new ScheduleIsAlreadyEndException("해당 일정은 이미 종료되었습니다.");
-        }
-    }
-
-    private void changeScheduleInfo(ScheduleRequestDto requestDto, Schedule schedule, Member member, Team team) {
-        changeName(schedule, requestDto, member, team);
-        changeTime(schedule, requestDto, member, team);
-    }
-
-    private void changeTime(Schedule schedule, ScheduleRequestDto requestDto, Member member, Team team) {
-        if (schedule.isTimeDifferent(requestDto.startTime(), requestDto.endTime())) {
-            validateOwnerOrLeader(schedule, member, team);
-            if (schedule.isStartTimeDifferent(requestDto.startTime())) {
-                validateScheduleDuplicate(team.getId(), requestDto);
-            }
-            validateScheduleTimeIntoTeamTime(requestDto, team);
-            validateEndTimeIsAfterNow(requestDto.endTime());
-            schedule.setTime(requestDto.startTime(), requestDto.endTime());
-        }
-    }
-
-    private void changeName(Schedule schedule, ScheduleRequestDto requestDto, Member member, Team team) {
-        if (schedule.isNameDifferent(requestDto.name())) {
-            validateOwnerOrLeader(schedule, member, team);
-            schedule.changeName(requestDto.name());
-        }
-    }
-
-
-    private void validateEndTimeIsAfterNow(LocalDateTime endTime) {
-        if (LocalDateTime.now(clock).isAfter(endTime)) {
-            throw new IllegalArgumentException("일정의 종료 시점은 현재보다 미래여야 합니다.");
-        }
-    }
-
-    private void validateScheduleTimeIntoTeamTime(ScheduleRequestDto requestDto, Team team) {
-        if (team.getStartDate().isAfter(requestDto.startTime().toLocalDate())) {
-            throw new IllegalArgumentException("일정 시작 시간이 팀의 시작 시간 이후여야 합니다.");
-        }
-        if (team.getEndDate() != null &&
-                team.getEndDate().isBefore(requestDto.endTime().toLocalDate())) {
-            throw new IllegalArgumentException("일정 종료 시간이 팀의 종료 시간 이전이어야 합니다.");
-        }
-    }
-
-    private void validateOwnerOrLeader(Schedule schedule, Member member, Team team) {
-        if (!(schedule.getOwner().equals(member) || team.getLeader().equals(member))) {
-            throw new SecurityException("일정을 생성한 사람, 혹은 팀장만 일정을 수정할 수 있습니다.");
-        }
-    }
-
-    private void validateScheduleDuplicate(Long teamId, ScheduleRequestDto requestDto) {
-        if (scheduleRepository.findByTeamIdAndStartTime(teamId, requestDto.startTime()).isPresent())
-            throw new ScheduleAlreadyExistException("이미 같은 시작시간에 일정이 있습니다.");
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -10,6 +10,7 @@ import com.feedhanjum.back_end.team.domain.TeamJoinToken;
 import com.feedhanjum.back_end.team.service.TeamService;
 import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
 import com.feedhanjum.back_end.team.service.dto.TeamUpdateDto;
+import com.feedhanjum.back_end.teamplanorchestration.service.TeamPlanOrchestrationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,6 +32,7 @@ public class TeamController {
     private final TeamService teamService;
     private final MemberService memberService;
     private final ScheduleService scheduleService;
+    private final TeamPlanOrchestrationService teamPlanOrchestrationService;
 
     @Operation(summary = "팀 생성", description = "로그인한 사용자를 팀장으로 하는 팀을 생성한다.")
     @ApiResponses({
@@ -117,7 +119,7 @@ public class TeamController {
     })
     @PostMapping("/{teamId}")
     public ResponseEntity<TeamResponse> updateTeamInfo(@Login Long memberId, @PathVariable Long teamId, @Valid @RequestBody TeamUpdateRequest request) {
-        Team team = teamService.updateTeamInfo(memberId, teamId, new TeamUpdateDto(request));
+        Team team = teamPlanOrchestrationService.updateTeamInfo(memberId, teamId, new TeamUpdateDto(request));
         TeamResponse teamResponse = new TeamResponse(team);
         return ResponseEntity.ok(teamResponse);
     }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamCreateRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamCreateRequest.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @Schema(description = "팀 생성 요청")
 public record TeamCreateRequest(
         @Schema(description = "팀 이름")
-        @NotBlank @Size(min = 1, max = 20) String name,
+        @NotBlank @Size(min = 1, max = 10) String name,
         @Schema(description = "시작 날짜")
         @NotNull LocalDate startDate,
         @Schema(description = "종료 날짜")

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamUpdateRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/dto/TeamUpdateRequest.java
@@ -9,8 +9,8 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record TeamUpdateRequest(
-        @Schema(description = "팀 이름 (1~20자)")
-        @NotBlank @Size(min = 1, max = 20) String name,
+        @Schema(description = "팀 이름 (1~10자)")
+        @NotBlank @Size(min = 1, max = 10) String name,
         @Schema(description = "시작 날짜")
         @NotNull LocalDate startDate,
         @Schema(description = "종료 날짜")

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -172,7 +172,7 @@ public class Team {
     }
 
     private void validateDuration(LocalDate startDate, LocalDate endDate, LocalDate now) {
-        if (endDate != null && !startDate.isBefore(endDate)) {
+        if (endDate != null && startDate.isAfter(endDate)) {
             throw new IllegalArgumentException("프로젝트 시작 시간이 종료 시간보다 앞서야 합니다.");
         }
         if (endDate != null && endDate.isBefore(now)) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
@@ -1,7 +1,16 @@
 package com.feedhanjum.back_end.team.repository;
 
 import com.feedhanjum.back_end.team.domain.Team;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from Team t where t.id = :id")
+    Optional<Team> findByIdForUpdate(@Param("id") Long id);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
@@ -22,7 +22,6 @@ import com.feedhanjum.back_end.team.service.dto.TeamUpdateDto;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
@@ -111,7 +110,7 @@ public class TeamPlanOrchestrationService {
      * @throws IllegalArgumentException            일정의 시간 설정이 잘못된 경우
      */
 
-    @Transactional(isolation = Isolation.REPEATABLE_READ)
+    @Transactional
     public void updateSchedule(Long memberId, Long teamId, Long scheduleId, ScheduleRequestDto requestDto) {
         Team team = teamRepository.findByIdForUpdate(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));

--- a/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
@@ -1,0 +1,184 @@
+package com.feedhanjum.back_end.teamplanorchestration.service;
+
+import com.feedhanjum.back_end.event.EventPublisher;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.schedule.domain.Schedule;
+import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
+import com.feedhanjum.back_end.schedule.exception.ScheduleAlreadyExistException;
+import com.feedhanjum.back_end.schedule.exception.ScheduleIsAlreadyEndException;
+import com.feedhanjum.back_end.schedule.exception.ScheduleMembershipNotFoundException;
+import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
+import com.feedhanjum.back_end.schedule.repository.ScheduleQueryRepository;
+import com.feedhanjum.back_end.schedule.repository.ScheduleRepository;
+import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
+import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
+import com.feedhanjum.back_end.team.service.dto.TeamUpdateDto;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class TeamPlanOrchestrationService {
+
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final ScheduleMemberRepository scheduleMemberRepository;
+    private final MemberQueryRepository memberQueryRepository;
+    private final ScheduleQueryRepository scheduleQueryRepository;
+    private final EventPublisher eventPublisher;
+    private final Clock clock;
+
+    /**
+     * @throws IllegalArgumentException 시작 시간이 종료 시간보다 앞서지 않을 경우
+     * @throws EntityNotFoundException  팀이 존재하지 않는 경우
+     * @throws SecurityException        요청자가 팀장이 아닐 경우
+     */
+    @Transactional
+    public Team updateTeamInfo(Long leaderId, Long teamId, TeamUpdateDto teamUpdateDto) {
+        Team team = teamRepository.findByIdForUpdate(teamId)
+                .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+        Member leader = memberRepository.findById(leaderId)
+                .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
+
+        LocalDateTime earliestStartTime = scheduleQueryRepository.findEarliestStartTimeByTeamId(teamId).orElse(null);
+        LocalDateTime latestEndTime = scheduleQueryRepository.findLatestEndTimeByTeamId(teamId).orElse(null);
+
+        if (earliestStartTime != null && teamUpdateDto.startDate().atStartOfDay().isAfter(earliestStartTime)) {
+            throw new IllegalArgumentException("팀 시작 날짜는 팀 내 존재하는 일정의 가장 빠른 시작 시점보다 빠를 수 없습니다.");
+        }
+
+        if (latestEndTime != null
+                && teamUpdateDto.endDate() != null
+                && teamUpdateDto.endDate().plusDays(1).atStartOfDay().isBefore(latestEndTime)) {
+            throw new IllegalArgumentException("팀 종료 날짜는 팀 내 존재하는 일정의 가장 늦은 종료 시점보다 느릴 수 없습니다.");
+        }
+
+        team.updateInfo(leader, teamUpdateDto.teamName(), teamUpdateDto.startDate(), teamUpdateDto.endDate(), teamUpdateDto.feedbackType(), LocalDate.now(clock));
+        return team;
+    }
+
+    /**
+     * 일정을 생성하는 메소드
+     *
+     * @throws EntityNotFoundException         사용자 혹은 팀이 존재하지 않는 경우
+     * @throws TeamMembershipNotFoundException 해당 사용자가 팀에 가입한 상태가 아닌경우
+     * @throws ScheduleAlreadyExistException   해당 일정의 시작 시간에 일정이 존재하는 경우
+     * @throws RuntimeException                내부 서버 오류: 방금 조회한 사용자 ID가 사라짐
+     */
+    @Transactional
+    public void createSchedule(Long memberId, Long teamId, ScheduleRequestDto requestDto) {
+        Team team = teamRepository.findByIdForUpdate(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+        teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).orElseThrow(() -> new TeamMembershipNotFoundException("해당 팀에 존재하는 사람만 일정을 생성할 수 있습니다."));
+
+        validateScheduleDuplicate(teamId, requestDto);
+        validateScheduleTimeIntoTeamTime(requestDto, team);
+        validateEndTimeIsAfterNow(requestDto.endTime());
+
+        Schedule schedule = scheduleRepository.save(
+                new Schedule(
+                        requestDto.name(),
+                        requestDto.startTime(),
+                        requestDto.endTime(),
+                        team,
+                        member));
+
+        memberQueryRepository.findMembersByTeamId(teamId).forEach(m -> scheduleMemberRepository.save(new ScheduleMember(schedule, m)));
+        ScheduleMember scheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, schedule.getId()).orElseThrow(() -> new RuntimeException("내부 서버 에러: 방금 조회한 사용자 ID가 사라짐"));
+        scheduleMember.setTodos(requestDto.todos());
+        eventPublisher.publishEvent(new ScheduleCreatedEvent(schedule.getId()));
+    }
+
+    /**
+     * @throws SecurityException                   일정 내용을 수정하려는 사람이 팀장, 일정의 주인이 아닌 경우
+     * @throws EntityNotFoundException             팀, 사용자 또는 일정을 찾을 수 없는 경우
+     * @throws ScheduleMembershipNotFoundException 회원이 해당 일정과 연관이 없을 경우
+     * @throws IllegalArgumentException            일정의 시간 설정이 잘못된 경우
+     */
+
+    @Transactional(isolation = Isolation.REPEATABLE_READ)
+    public void updateSchedule(Long memberId, Long teamId, Long scheduleId, ScheduleRequestDto requestDto) {
+        Team team = teamRepository.findByIdForUpdate(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
+        Schedule schedule = scheduleRepository.findById(scheduleId).orElseThrow(() -> new EntityNotFoundException("해당 일정을 찾을 수 없습니다."));
+        validateIsEnded(schedule);
+        ScheduleMember scheduleMember = scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, scheduleId)
+                .orElseThrow(() -> new ScheduleMembershipNotFoundException("해당 일정을 찾을 수 없습니다."));
+
+        changeScheduleInfo(requestDto, schedule, member, team);
+        scheduleMember.setTodos(requestDto.todos());
+    }
+
+    private void validateIsEnded(Schedule schedule) {
+        if (schedule.getEndTime().isBefore(LocalDateTime.now(clock))) {
+            throw new ScheduleIsAlreadyEndException("해당 일정은 이미 종료되었습니다.");
+        }
+    }
+
+    private void changeTime(Schedule schedule, ScheduleRequestDto requestDto, Member member, Team team) {
+        if (schedule.isTimeDifferent(requestDto.startTime(), requestDto.endTime())) {
+            validateOwnerOrLeader(schedule, member, team);
+            if (schedule.isStartTimeDifferent(requestDto.startTime())) {
+                validateScheduleDuplicate(team.getId(), requestDto);
+            }
+            validateScheduleTimeIntoTeamTime(requestDto, team);
+            validateEndTimeIsAfterNow(requestDto.endTime());
+            schedule.setTime(requestDto.startTime(), requestDto.endTime());
+        }
+    }
+
+    private void changeName(Schedule schedule, ScheduleRequestDto requestDto, Member member, Team team) {
+        if (schedule.isNameDifferent(requestDto.name())) {
+            validateOwnerOrLeader(schedule, member, team);
+            schedule.changeName(requestDto.name());
+        }
+    }
+
+    private void changeScheduleInfo(ScheduleRequestDto requestDto, Schedule schedule, Member member, Team team) {
+        changeName(schedule, requestDto, member, team);
+        changeTime(schedule, requestDto, member, team);
+    }
+
+    private void validateEndTimeIsAfterNow(LocalDateTime endTime) {
+        if (LocalDateTime.now(clock).isAfter(endTime)) {
+            throw new IllegalArgumentException("일정의 종료 시점은 현재보다 미래여야 합니다.");
+        }
+    }
+
+    private void validateOwnerOrLeader(Schedule schedule, Member member, Team team) {
+        if (!(schedule.getOwner().equals(member) || team.getLeader().equals(member))) {
+            throw new SecurityException("일정을 생성한 사람, 혹은 팀장만 일정을 수정할 수 있습니다.");
+        }
+    }
+
+
+    private void validateScheduleTimeIntoTeamTime(ScheduleRequestDto requestDto, Team team) {
+        if (team.getStartDate().isAfter(requestDto.startTime().toLocalDate())) {
+            throw new IllegalArgumentException("일정 시작 시간이 팀의 시작 시간 이후여야 합니다.");
+        }
+        if (team.getEndDate() != null &&
+                team.getEndDate().isBefore(requestDto.endTime().toLocalDate())) {
+            throw new IllegalArgumentException("일정 종료 시간이 팀의 종료 시간 이전이어야 합니다.");
+        }
+    }
+
+    private void validateScheduleDuplicate(Long teamId, ScheduleRequestDto requestDto) {
+        if (scheduleRepository.findByTeamIdAndStartTime(teamId, requestDto.startTime()).isPresent())
+            throw new ScheduleAlreadyExistException("이미 같은 시작시간에 일정이 있습니다.");
+    }
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/schedule/controller/ScheduleControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/schedule/controller/ScheduleControllerTest.java
@@ -4,6 +4,7 @@ import com.feedhanjum.back_end.schedule.controller.dto.ScheduleRequest;
 import com.feedhanjum.back_end.schedule.domain.Todo;
 import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
+import com.feedhanjum.back_end.teamplanorchestration.service.TeamPlanOrchestrationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,9 @@ public class ScheduleControllerTest {
     private ScheduleController scheduleController;
 
     @Mock
+    private TeamPlanOrchestrationService teamPlanOrchestrationService;
+
+    @Mock
     private ScheduleService scheduleService;
     @Test
     @DisplayName("일정 생성 컨트롤러 성공 테스트")
@@ -38,7 +42,7 @@ public class ScheduleControllerTest {
         Todo hehe = new Todo("hehe");
         ScheduleRequest request = new ScheduleRequest("haha", LocalDateTime.now(), LocalDateTime.now().plusDays(10), List.of(hehe));
         ScheduleRequestDto scheduleRequestDto = new ScheduleRequestDto(request);
-        doNothing().when(scheduleService).createSchedule(memberId, teamId, scheduleRequestDto);
+        doNothing().when(teamPlanOrchestrationService).createSchedule(memberId, teamId, scheduleRequestDto);
 
         // when
         ResponseEntity<Void> result = scheduleController.createSchedule(memberId, teamId, request);
@@ -46,7 +50,7 @@ public class ScheduleControllerTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        verify(scheduleService).createSchedule(memberId, teamId, new ScheduleRequestDto(request));
+        verify(teamPlanOrchestrationService).createSchedule(memberId, teamId, new ScheduleRequestDto(request));
     }
     @Test
     @DisplayName("스케줄 수정 요청 성공")

--- a/back-end/src/test/java/com/feedhanjum/back_end/schedule/service/ScheduleServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/schedule/service/ScheduleServiceTest.java
@@ -1,39 +1,20 @@
 package com.feedhanjum.back_end.schedule.service;
 
 import com.feedhanjum.back_end.event.EventPublisher;
-import com.feedhanjum.back_end.member.domain.Member;
 import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
 import com.feedhanjum.back_end.member.repository.MemberRepository;
-import com.feedhanjum.back_end.schedule.domain.Schedule;
-import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
-import com.feedhanjum.back_end.schedule.domain.Todo;
-import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
-import com.feedhanjum.back_end.schedule.exception.ScheduleAlreadyExistException;
-import com.feedhanjum.back_end.schedule.exception.ScheduleIsAlreadyEndException;
 import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleQueryRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleRepository;
-import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
-import com.feedhanjum.back_end.team.domain.Team;
-import com.feedhanjum.back_end.team.domain.TeamMember;
-import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
 import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
 import com.feedhanjum.back_end.team.repository.TeamRepository;
-import jakarta.persistence.EntityNotFoundException;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import com.feedhanjum.back_end.teamplanorchestration.service.TeamPlanOrchestrationService;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.*;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import java.time.Clock;
 
 @ExtendWith(MockitoExtension.class)
 class ScheduleServiceTest {
@@ -66,213 +47,10 @@ class ScheduleServiceTest {
     MemberQueryRepository memberQueryRepository;
 
     @InjectMocks
+    TeamPlanOrchestrationService teamPlanOrchestrationService;
+
+    @InjectMocks
     ScheduleService scheduleService;
 
-    @Test
-    @DisplayName("일정 생성 성공")
-    void createSchedule_성공() {
-        // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-        when(requestDto.name()).thenReturn("haha");
-        LocalDateTime startTime = LocalDateTime.of(2025, 3, 1, 10, 0);
-        LocalDateTime endTime = LocalDateTime.of(2025, 3, 1, 12, 0);
-        when(requestDto.startTime()).thenReturn(startTime);
-        when(requestDto.endTime()).thenReturn(endTime);
-        Todo hehe = new Todo("hoho");
-        when(requestDto.todos()).thenReturn(List.of(hehe));
 
-        Team team = mock(Team.class);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
-        when(team.getStartDate()).thenReturn(LocalDate.of(2025, 2, 28));
-        when(team.getEndDate()).thenReturn(LocalDate.of(2025, 3, 2));
-
-        Member member = mock(Member.class);
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-
-        // 존재하는 팀 멤버 체크 (dummy object 사용)
-        when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
-                .thenReturn(Optional.of(new TeamMember(team, member)));
-
-        // 중복 일정 없음
-        when(scheduleRepository.findByTeamIdAndStartTime(teamId, startTime))
-                .thenReturn(Optional.empty());
-
-        // clock 고정
-        when(clock.instant()).thenReturn(Instant.parse("2025-02-28T09:00:00Z"));
-        when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
-
-        // 저장될 일정 mock
-        Schedule schedule = mock(Schedule.class);
-        when(schedule.getId()).thenReturn(100L);
-        when(scheduleRepository.save(any(Schedule.class))).thenReturn(schedule);
-
-        Member memberFromTeam = mock(Member.class);
-        when(memberQueryRepository.findMembersByTeamId(teamId)).thenReturn(Collections.singletonList(memberFromTeam));
-
-        ScheduleMember scheduleMember = mock(ScheduleMember.class);
-        when(scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, 100L))
-                .thenReturn(Optional.of(scheduleMember));
-
-        // when
-        scheduleService.createSchedule(memberId, teamId, requestDto);
-
-        // then
-        verify(scheduleMember, times(1)).setTodos(List.of(hehe));
-        verify(eventPublisher).publishEvent(new ScheduleCreatedEvent(schedule.getId()));
-    }
-
-    @Test
-    @DisplayName("일정 생성 실패 - 팀 미존재")
-    void createSchedule_팀미존재() {
-        // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
-
-        // when, then
-        assertThatThrownBy(() ->
-                scheduleService.createSchedule(memberId, teamId, requestDto)
-        ).isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("팀을 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("일정 생성 실패 - 사용자 미존재")
-    void createSchedule_사용자미존재() {
-        // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-        Team team = mock(Team.class);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
-        when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
-
-        // when, then
-        assertThatThrownBy(() ->
-                scheduleService.createSchedule(memberId, teamId, requestDto)
-        ).isInstanceOf(EntityNotFoundException.class)
-                .hasMessageContaining("해당 사용자를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("일정 생성 실패 - 팀 멤버 아님")
-    void createSchedule_팀멤버아님() {
-        // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-        Team team = mock(Team.class);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
-        Member member = mock(Member.class);
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
-                .thenReturn(Optional.empty());
-
-        // when, then
-        assertThatThrownBy(() ->
-                scheduleService.createSchedule(memberId, teamId, requestDto)
-        ).isInstanceOf(TeamMembershipNotFoundException.class)
-                .hasMessageContaining("해당 팀에 존재하는 사람만 일정을 생성할 수 있습니다.");
-    }
-
-    @Test
-    @DisplayName("일정 생성 실패 - 중복 일정 존재")
-    void createSchedule_중복일정존재() {
-        // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-        when(requestDto.startTime()).thenReturn(LocalDateTime.of(2025, 3, 1, 10, 0));
-        Team team = mock(Team.class);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
-        Member member = mock(Member.class);
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-        when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
-                .thenReturn(Optional.of(new TeamMember(team, member)));
-
-        when(scheduleRepository.findByTeamIdAndStartTime(teamId, LocalDateTime.of(2025, 3, 1, 10, 0)))
-                .thenReturn(Optional.of(mock(Schedule.class)));
-
-        // when, then
-        assertThatThrownBy(() ->
-                scheduleService.createSchedule(memberId, teamId, requestDto)
-        ).isInstanceOf(ScheduleAlreadyExistException.class)
-                .hasMessageContaining("이미 같은 시작시간에 일정이 있습니다.");
-    }
-
-    @Test
-    @DisplayName("일정 수정 성공")
-    void updateSchedule_성공() {
-        // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        Long scheduleId = 100L;
-        ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-        when(requestDto.name()).thenReturn("haha");
-        LocalDateTime newStartTime = LocalDateTime.of(2025, 4, 1, 10, 0);
-        LocalDateTime newEndTime = LocalDateTime.of(2025, 4, 1, 12, 0);
-        when(requestDto.startTime()).thenReturn(newStartTime);
-        when(requestDto.endTime()).thenReturn(newEndTime);
-        Todo hehe = new Todo("hehe");
-        when(requestDto.todos()).thenReturn(List.of(hehe));
-
-        Team team = mock(Team.class);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
-
-        Member member = mock(Member.class);
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-
-        Schedule schedule = mock(Schedule.class);
-        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
-        LocalDateTime futureTime = LocalDateTime.of(2025, 4, 1, 13, 0);
-        when(schedule.getEndTime()).thenReturn(futureTime);
-
-        ScheduleMember scheduleMember = mock(ScheduleMember.class);
-        when(scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, scheduleId))
-                .thenReturn(Optional.of(scheduleMember));
-
-        // clock 고정
-        when(clock.instant()).thenReturn(Instant.parse("2025-04-01T09:00:00Z"));
-        when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
-
-        // when
-        scheduleService.updateSchedule(memberId, teamId, scheduleId, requestDto);
-
-        // then
-        verify(scheduleMember, times(1)).setTodos(List.of(hehe));
-    }
-
-    @Test
-    @DisplayName("일정 수정 실패 - 이미 종료된 일정")
-    void updateSchedule_종료된일정() {
-        // given
-        Long memberId = 1L;
-        Long teamId = 1L;
-        Long scheduleId = 100L;
-        ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-
-        Team team = mock(Team.class);
-        when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
-
-        Member member = mock(Member.class);
-        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-
-        Schedule schedule = mock(Schedule.class);
-        when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
-        // 종료 시간이 현재 시간보다 이전
-        LocalDateTime pastTime = LocalDateTime.of(2025, 1, 1, 10, 0);
-        when(schedule.getEndTime()).thenReturn(pastTime);
-
-        when(clock.instant()).thenReturn(Instant.parse("2025-02-01T09:00:00Z"));
-        when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
-
-        // when, then
-        assertThatThrownBy(() ->
-                scheduleService.updateSchedule(memberId, teamId, scheduleId, requestDto)
-        ).isInstanceOf(ScheduleIsAlreadyEndException.class)
-                .hasMessageContaining("해당 일정은 이미 종료되었습니다.");
-    }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerIntegrationTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerIntegrationTest.java
@@ -125,10 +125,10 @@ public class TeamControllerIntegrationTest {
         void test1() throws JsonProcessingException {
             // given
             Member leader = member1;
-            Team team = createTeamWithoutId("teamToUpdate", leader);
+            Team team = createTeamWithoutId("teamUpdate", leader);
             teamRepository.save(team);
 
-            TeamUpdateRequest request = new TeamUpdateRequest("updatedTeamName", LocalDate.now(), LocalDate.now().plusDays(5), FeedbackType.IDENTIFIED);
+            TeamUpdateRequest request = new TeamUpdateRequest("updateName", LocalDate.now(), LocalDate.now().plusDays(5), FeedbackType.IDENTIFIED);
 
             // when & then
             assertThat(
@@ -141,13 +141,13 @@ public class TeamControllerIntegrationTest {
                     .body()
                     .satisfies(result -> {
                         TeamResponse response = mapper.readValue(result, TeamResponse.class);
-                        assertThat(response.name()).isEqualTo("updatedTeamName");
+                        assertThat(response.name()).isEqualTo("updateName");
                         assertThat(response.startDate()).isEqualTo(request.startDate());
                         assertThat(response.endDate()).isEqualTo(request.endDate());
                         assertThat(response.feedbackType()).isEqualTo(request.feedbackType());
 
                         Team updatedTeam = teamRepository.findById(team.getId()).orElseThrow();
-                        assertThat(updatedTeam.getName()).isEqualTo("updatedTeamName");
+                        assertThat(updatedTeam.getName()).isEqualTo("updateName");
                         assertThat(updatedTeam.getStartDate()).isEqualTo(request.startDate());
                         assertThat(updatedTeam.getEndDate()).isEqualTo(request.endDate());
                     });
@@ -159,10 +159,10 @@ public class TeamControllerIntegrationTest {
             // given
             Member leader = member1;
             Member nonLeader = member2;
-            Team team = createTeamWithoutId("teamToUpdate", leader);
+            Team team = createTeamWithoutId("teamUpdate", leader);
             teamRepository.save(team);
 
-            TeamUpdateRequest request = new TeamUpdateRequest("updatedTeamName", LocalDate.now(), LocalDate.now().plusDays(5), FeedbackType.ANONYMOUS);
+            TeamUpdateRequest request = new TeamUpdateRequest("updateName", LocalDate.now(), LocalDate.now().plusDays(5), FeedbackType.ANONYMOUS);
 
             // when & then
             assertThat(
@@ -180,7 +180,7 @@ public class TeamControllerIntegrationTest {
             // given
             Member leader = member1;
 
-            TeamUpdateRequest request = new TeamUpdateRequest("updatedTeamName", LocalDate.now(), LocalDate.now().plusDays(5), FeedbackType.IDENTIFIED);
+            TeamUpdateRequest request = new TeamUpdateRequest("updateName", LocalDate.now(), LocalDate.now().plusDays(5), FeedbackType.IDENTIFIED);
 
             // when & then
             assertThat(

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerTest.java
@@ -14,6 +14,7 @@ import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.service.TeamService;
 import com.feedhanjum.back_end.team.service.dto.TeamCreateDto;
 import com.feedhanjum.back_end.team.service.dto.TeamUpdateDto;
+import com.feedhanjum.back_end.teamplanorchestration.service.TeamPlanOrchestrationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +41,9 @@ class TeamControllerTest {
 
     @Mock
     private ScheduleService scheduleService;
+
+    @Mock
+    private TeamPlanOrchestrationService teamPlanOrchestrationService;
 
     @InjectMocks
     private TeamController teamController;
@@ -213,12 +217,12 @@ class TeamControllerTest {
         TeamUpdateRequest teamUpdateRequest = new TeamUpdateRequest("hehe", LocalDate.now().plusDays(1), LocalDate.now().plusDays(10), FeedbackType.IDENTIFIED);
 
         Team team = new Team("haha", mock(Member.class), LocalDate.now().plusDays(1), LocalDate.now().plusDays(10), FeedbackType.ANONYMOUS, LocalDate.now());
-        when(teamService.updateTeamInfo(memberId, teamId, new TeamUpdateDto(teamUpdateRequest))).thenReturn(team);
+        when(teamPlanOrchestrationService.updateTeamInfo(memberId, teamId, new TeamUpdateDto(teamUpdateRequest))).thenReturn(team);
 
         // when
         teamController.updateTeamInfo(memberId, teamId, teamUpdateRequest);
 
         // then
-        verify(teamService).updateTeamInfo(memberId, teamId, new TeamUpdateDto(teamUpdateRequest));
+        verify(teamPlanOrchestrationService).updateTeamInfo(memberId, teamId, new TeamUpdateDto(teamUpdateRequest));
     }
 }

--- a/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
@@ -14,7 +14,6 @@ import com.feedhanjum.back_end.schedule.exception.ScheduleIsAlreadyEndException;
 import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleQueryRepository;
 import com.feedhanjum.back_end.schedule.repository.ScheduleRepository;
-import com.feedhanjum.back_end.schedule.service.ScheduleService;
 import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
 import com.feedhanjum.back_end.team.domain.Team;
 import com.feedhanjum.back_end.team.domain.TeamMember;
@@ -75,9 +74,6 @@ class TeamPlanOrchestrationServiceTest {
 
     @InjectMocks
     TeamPlanOrchestrationService teamPlanOrchestrationService;
-
-    @InjectMocks
-    ScheduleService scheduleService;
 
     @Nested
     @DisplayName("팀 정보 업데이트")

--- a/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
@@ -1,0 +1,432 @@
+package com.feedhanjum.back_end.teamplanorchestration.service;
+
+import com.feedhanjum.back_end.event.EventPublisher;
+import com.feedhanjum.back_end.feedback.domain.FeedbackType;
+import com.feedhanjum.back_end.member.domain.Member;
+import com.feedhanjum.back_end.member.repository.MemberQueryRepository;
+import com.feedhanjum.back_end.member.repository.MemberRepository;
+import com.feedhanjum.back_end.schedule.domain.Schedule;
+import com.feedhanjum.back_end.schedule.domain.ScheduleMember;
+import com.feedhanjum.back_end.schedule.domain.Todo;
+import com.feedhanjum.back_end.schedule.event.ScheduleCreatedEvent;
+import com.feedhanjum.back_end.schedule.exception.ScheduleAlreadyExistException;
+import com.feedhanjum.back_end.schedule.exception.ScheduleIsAlreadyEndException;
+import com.feedhanjum.back_end.schedule.repository.ScheduleMemberRepository;
+import com.feedhanjum.back_end.schedule.repository.ScheduleQueryRepository;
+import com.feedhanjum.back_end.schedule.repository.ScheduleRepository;
+import com.feedhanjum.back_end.schedule.service.ScheduleService;
+import com.feedhanjum.back_end.schedule.service.dto.ScheduleRequestDto;
+import com.feedhanjum.back_end.team.domain.Team;
+import com.feedhanjum.back_end.team.domain.TeamMember;
+import com.feedhanjum.back_end.team.exception.TeamMembershipNotFoundException;
+import com.feedhanjum.back_end.team.repository.TeamMemberRepository;
+import com.feedhanjum.back_end.team.repository.TeamRepository;
+import com.feedhanjum.back_end.team.service.dto.TeamUpdateDto;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.feedhanjum.back_end.test.util.DomainTestUtils.createMemberWithId;
+import static com.feedhanjum.back_end.test.util.DomainTestUtils.createTeamWithId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TeamPlanOrchestrationServiceTest {
+
+    @Mock
+    Clock clock;
+
+    @Mock
+    TeamRepository teamRepository;
+
+    @Mock
+    TeamMemberRepository teamMemberRepository;
+
+    @Mock
+    ScheduleRepository scheduleRepository;
+
+    @Mock
+    ScheduleMemberRepository scheduleMemberRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    ScheduleQueryRepository scheduleQueryRepository;
+
+    @Mock
+    EventPublisher eventPublisher;
+
+    @Mock
+    MemberQueryRepository memberQueryRepository;
+
+    @InjectMocks
+    TeamPlanOrchestrationService teamPlanOrchestrationService;
+
+    @InjectMocks
+    ScheduleService scheduleService;
+
+    @Nested
+    @DisplayName("팀 정보 업데이트")
+    class UpdateTeamInfo {
+
+        @Test
+        @DisplayName("팀 정보 업데이트 성공")
+        void updateTeamInfo_성공() {
+            // given
+            Member leader = createMemberWithId("leader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
+            LocalDate startDate = LocalDate.of(2025, 1, 1);
+            LocalDate endDate = LocalDate.of(2025, 1, 2);
+            TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
+            Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
+
+            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
+
+            // when
+            Team updatedTeam = teamPlanOrchestrationService.updateTeamInfo(leader.getId(), team.getId(), teamUpdateDto);
+
+            // then
+            assertThat(updatedTeam.getName()).isEqualTo("haha");
+            assertThat(updatedTeam.getStartDate()).isEqualTo(startDate);
+            assertThat(updatedTeam.getEndDate()).isEqualTo(endDate);
+            assertThat(updatedTeam.getFeedbackType()).isEqualTo(FeedbackType.IDENTIFIED);
+        }
+
+        @Test
+        @DisplayName("시작 시간이 종료 시간보다 늦은 경우 예외 발생")
+        void updateTeamInfo_잘못된기간() {
+            // given
+            Member member = createMemberWithId("member");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
+            LocalDate startDate = LocalDate.of(2025, 1, 3);
+            LocalDate endDate = LocalDate.of(2025, 1, 2);
+            Team team = createTeamWithId("team", member);
+            TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
+
+            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+
+            // when, then
+            assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(member.getId(), team.getId(), teamUpdateDto))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("팀이 존재하지 않을 경우 예외 발생")
+        void updateTeamInfo_팀없음() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 10L;
+            LocalDate startDate = LocalDate.of(2025, 1, 1);
+            LocalDate endDate = LocalDate.of(2025, 1, 2);
+            TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.ANONYMOUS);
+
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(memberId, teamId, teamUpdateDto))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("팀을 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("요청자가 팀장이 아닐 경우 예외 발생")
+        void updateTeamInfo_팀장아님() {
+            // given
+            Member notLeader = createMemberWithId("notLeader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
+            LocalDate startDate = LocalDate.of(2025, 1, 1);
+            LocalDate endDate = LocalDate.of(2025, 1, 2);
+            Team team = createTeamWithId("team", createMemberWithId("leader"), startDate, endDate, LocalDate.now(clock));
+            TeamUpdateDto teamUpdateDto = new TeamUpdateDto("hoho", startDate, endDate, FeedbackType.ANONYMOUS);
+
+            when(memberRepository.findById(notLeader.getId())).thenReturn(Optional.of(notLeader));
+            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+
+            // when, then
+            assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(notLeader.getId(), team.getId(), teamUpdateDto))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("팀장이 아닙니다");
+        }
+
+        @Test
+        @DisplayName("팀의 종료 시점이 일정을 모두 포함하지 못할 경우 예외 발생")
+        void updateTeamInfo_기간초과1() {
+            // given
+            Member leader = createMemberWithId("leader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
+            LocalDate startDate = LocalDate.of(2025, 1, 1);
+            LocalDate endDate = LocalDate.of(2025, 1, 3);
+            TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
+            Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
+
+            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
+            when(scheduleQueryRepository.findLatestEndTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 4, 0, 10, 0)));
+
+            // when, then
+            assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(leader.getId(), team.getId(), teamUpdateDto))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("팀 종료 날짜는 팀 내 존재하는 일정의 가장 늦은 종료 시점보다 느릴 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("팀의 시작 시점이 일정을 모두 포함하지 못할 경우 예외 발생")
+        void updateTeamInfo_기간초과2() {
+            // given
+            Member leader = createMemberWithId("leader");
+            when(clock.instant()).thenReturn(LocalDate.of(2025, 1, 1).atStartOfDay(Clock.systemDefaultZone().getZone()).toInstant());
+            when(clock.getZone()).thenReturn(Clock.systemDefaultZone().getZone());
+            LocalDate startDate = LocalDate.of(2025, 1, 2);
+            LocalDate endDate = LocalDate.of(2025, 1, 3);
+            TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
+            Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
+
+            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
+            when(scheduleQueryRepository.findEarliestStartTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 1, 0, 10, 0)));
+
+            // when, then
+            assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(leader.getId(), team.getId(), teamUpdateDto))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("팀 시작 날짜는 팀 내 존재하는 일정의 가장 빠른 시작 시점보다 빠를 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("일정 생성 테스트")
+    class CreateSchedule {
+
+        @Test
+        @DisplayName("일정 생성 성공")
+        void createSchedule_성공() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 1L;
+            ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
+            when(requestDto.name()).thenReturn("haha");
+            LocalDateTime startTime = LocalDateTime.of(2025, 3, 1, 10, 0);
+            LocalDateTime endTime = LocalDateTime.of(2025, 3, 1, 12, 0);
+            when(requestDto.startTime()).thenReturn(startTime);
+            when(requestDto.endTime()).thenReturn(endTime);
+            Todo hehe = new Todo("hoho");
+            when(requestDto.todos()).thenReturn(List.of(hehe));
+
+            Team team = mock(Team.class);
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            when(team.getStartDate()).thenReturn(LocalDate.of(2025, 2, 28));
+            when(team.getEndDate()).thenReturn(LocalDate.of(2025, 3, 2));
+
+            Member member = mock(Member.class);
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+            // 존재하는 팀 멤버 체크 (dummy object 사용)
+            when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
+                    .thenReturn(Optional.of(new TeamMember(team, member)));
+
+            // 중복 일정 없음
+            when(scheduleRepository.findByTeamIdAndStartTime(teamId, startTime))
+                    .thenReturn(Optional.empty());
+
+            // clock 고정
+            when(clock.instant()).thenReturn(Instant.parse("2025-02-28T09:00:00Z"));
+            when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
+
+            // 저장될 일정 mock
+            Schedule schedule = mock(Schedule.class);
+            when(schedule.getId()).thenReturn(100L);
+            when(scheduleRepository.save(any(Schedule.class))).thenReturn(schedule);
+
+            Member memberFromTeam = mock(Member.class);
+            when(memberQueryRepository.findMembersByTeamId(teamId)).thenReturn(Collections.singletonList(memberFromTeam));
+
+            ScheduleMember scheduleMember = mock(ScheduleMember.class);
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, 100L))
+                    .thenReturn(Optional.of(scheduleMember));
+
+            // when
+            teamPlanOrchestrationService.createSchedule(memberId, teamId, requestDto);
+
+            // then
+            verify(scheduleMember, times(1)).setTodos(List.of(hehe));
+            verify(eventPublisher).publishEvent(new ScheduleCreatedEvent(schedule.getId()));
+        }
+
+        @Test
+        @DisplayName("일정 생성 실패 - 팀 미존재")
+        void createSchedule_팀미존재() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 1L;
+            ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() ->
+                    teamPlanOrchestrationService.createSchedule(memberId, teamId, requestDto)
+            ).isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("팀을 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("일정 생성 실패 - 사용자 미존재")
+        void createSchedule_사용자미존재() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 1L;
+            ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
+            Team team = mock(Team.class);
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() ->
+                    teamPlanOrchestrationService.createSchedule(memberId, teamId, requestDto)
+            ).isInstanceOf(EntityNotFoundException.class)
+                    .hasMessageContaining("해당 사용자를 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("일정 생성 실패 - 팀 멤버 아님")
+        void createSchedule_팀멤버아님() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 1L;
+            ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
+            Team team = mock(Team.class);
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            Member member = mock(Member.class);
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
+                    .thenReturn(Optional.empty());
+
+            // when, then
+            assertThatThrownBy(() ->
+                    teamPlanOrchestrationService.createSchedule(memberId, teamId, requestDto)
+            ).isInstanceOf(TeamMembershipNotFoundException.class)
+                    .hasMessageContaining("해당 팀에 존재하는 사람만 일정을 생성할 수 있습니다.");
+        }
+
+        @Test
+        @DisplayName("일정 생성 실패 - 중복 일정 존재")
+        void createSchedule_중복일정존재() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 1L;
+            ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
+            when(requestDto.startTime()).thenReturn(LocalDateTime.of(2025, 3, 1, 10, 0));
+            Team team = mock(Team.class);
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            Member member = mock(Member.class);
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+            when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
+                    .thenReturn(Optional.of(new TeamMember(team, member)));
+
+            when(scheduleRepository.findByTeamIdAndStartTime(teamId, LocalDateTime.of(2025, 3, 1, 10, 0)))
+                    .thenReturn(Optional.of(mock(Schedule.class)));
+
+            // when, then
+            assertThatThrownBy(() ->
+                    teamPlanOrchestrationService.createSchedule(memberId, teamId, requestDto)
+            ).isInstanceOf(ScheduleAlreadyExistException.class)
+                    .hasMessageContaining("이미 같은 시작시간에 일정이 있습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("일정 수정 테스트")
+    class UpdateSchedule {
+
+        @Test
+        @DisplayName("일정 수정 성공")
+        void updateSchedule_성공() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 1L;
+            Long scheduleId = 100L;
+            ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
+            when(requestDto.name()).thenReturn("haha");
+            LocalDateTime newStartTime = LocalDateTime.of(2025, 4, 1, 10, 0);
+            LocalDateTime newEndTime = LocalDateTime.of(2025, 4, 1, 12, 0);
+            when(requestDto.startTime()).thenReturn(newStartTime);
+            when(requestDto.endTime()).thenReturn(newEndTime);
+            Todo hehe = new Todo("hehe");
+            when(requestDto.todos()).thenReturn(List.of(hehe));
+
+            Team team = mock(Team.class);
+            when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+
+            Member member = mock(Member.class);
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+            Schedule schedule = mock(Schedule.class);
+            when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+            LocalDateTime futureTime = LocalDateTime.of(2025, 4, 1, 13, 0);
+            when(schedule.getEndTime()).thenReturn(futureTime);
+
+            ScheduleMember scheduleMember = mock(ScheduleMember.class);
+            when(scheduleMemberRepository.findByMemberIdAndScheduleId(memberId, scheduleId))
+                    .thenReturn(Optional.of(scheduleMember));
+
+            // clock 고정
+            when(clock.instant()).thenReturn(Instant.parse("2025-04-01T09:00:00Z"));
+            when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
+
+            // when
+            teamPlanOrchestrationService.updateSchedule(memberId, teamId, scheduleId, requestDto);
+
+            // then
+            verify(scheduleMember, times(1)).setTodos(List.of(hehe));
+        }
+
+        @Test
+        @DisplayName("일정 수정 실패 - 이미 종료된 일정")
+        void updateSchedule_종료된일정() {
+            // given
+            Long memberId = 1L;
+            Long teamId = 1L;
+            Long scheduleId = 100L;
+            ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
+
+            Team team = mock(Team.class);
+            when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+
+            Member member = mock(Member.class);
+            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+            Schedule schedule = mock(Schedule.class);
+            when(scheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+            // 종료 시간이 현재 시간보다 이전
+            LocalDateTime pastTime = LocalDateTime.of(2025, 1, 1, 10, 0);
+            when(schedule.getEndTime()).thenReturn(pastTime);
+
+            when(clock.instant()).thenReturn(Instant.parse("2025-02-01T09:00:00Z"));
+            when(clock.getZone()).thenReturn(ZoneId.of("UTC"));
+
+            // when, then
+            assertThatThrownBy(() ->
+                    teamPlanOrchestrationService.updateSchedule(memberId, teamId, scheduleId, requestDto)
+            ).isInstanceOf(ScheduleIsAlreadyEndException.class)
+                    .hasMessageContaining("해당 일정은 이미 종료되었습니다.");
+        }
+    }
+}

--- a/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
@@ -373,7 +373,7 @@ class TeamPlanOrchestrationServiceTest {
             when(requestDto.todos()).thenReturn(List.of(hehe));
 
             Team team = mock(Team.class);
-            when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
 
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
@@ -408,7 +408,7 @@ class TeamPlanOrchestrationServiceTest {
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
 
             Team team = mock(Team.class);
-            when(teamRepository.findById(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
 
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));


### PR DESCRIPTION
# 관련 이슈
FD-388

# 변경된 점
- [x] 팀 정보 변경 , 일정 생성 로직의 트랜잭션 방향 설정
- [x] 팀 프로젝트 기간 변경 및 일정 생성 로직의 트랜잭션 방향이 팀 -> 일정으로 흐르도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new service for managing team schedules and updates, enhancing scheduling and team update operations.
- **Improvements**
  - Strengthened validations ensure correct ordering of dates for projects and schedules.
  - Adjusted team naming constraints now limit names to a maximum of 10 characters for greater clarity.
- **Bug Fixes**
  - Resolved issues related to schedule creation and updates by redirecting service calls to the new orchestration service.
- **Refactor**
  - Removed outdated methods from the schedule and team services, streamlining functionality.
- **Tests**
  - Added comprehensive tests for the new orchestration service, covering various scenarios for team and schedule management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->