### PR TITLE
[FD-399] 팀스페이스 디버깅

### DIFF
--- a/front-end/src/pages/teamspace/TeamSpaceEdit.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceEdit.jsx
@@ -61,7 +61,7 @@ export default function TeamSpaceEdit({ isFirst = false }) {
               onSuccess: () => {
                 hideModal();
                 reSelectTeam(teamId, selectedTeam, removeSelectedTeam);
-                navigate('/teamspace/list');
+                navigate(-2);
               },
             });
           }}

--- a/front-end/src/pages/teamspace/TeamSpaceList.jsx
+++ b/front-end/src/pages/teamspace/TeamSpaceList.jsx
@@ -42,7 +42,11 @@ export default function TeamSpaceList() {
             })
             .map((team) => (
               <button
-                onClick={() => navigate(`/teamspace/manage/${team.id}`)}
+                onClick={() =>
+                  navigate(`/teamspace/manage/${team.id}`, {
+                    state: { isEnded: showEndedTeams },
+                  })
+                }
                 key={team.id}
               >
                 <TeamElement

--- a/front-end/src/pages/teamspace/components/MemberElement.jsx
+++ b/front-end/src/pages/teamspace/components/MemberElement.jsx
@@ -79,7 +79,7 @@ export default function MemberElement({ teamId, member, leaderId, iamLeader }) {
               onSuccess: () => {
                 hideModal();
                 reSelectTeam(teamId, selectedTeam, removeSelectedTeam);
-                navigate('/teamspace/list');
+                navigate(-1);
               },
             });
           }}

--- a/front-end/src/utility/inputChecker.js
+++ b/front-end/src/utility/inputChecker.js
@@ -134,6 +134,9 @@ export const isValidTeamName = (teamSpaceName) => {
   if (isEmpty(teamSpaceName)) {
     showToast('팀 이름을 입력해주세요');
     return false;
+  } else if (teamSpaceName.length > 8) {
+    showToast('팀 이름은 최대 8자까지 가능해요');
+    return false;
   }
   return true;
 };

--- a/front-end/src/utility/inputChecker.js
+++ b/front-end/src/utility/inputChecker.js
@@ -134,8 +134,8 @@ export const isValidTeamName = (teamSpaceName) => {
   if (isEmpty(teamSpaceName)) {
     showToast('팀 이름을 입력해주세요');
     return false;
-  } else if (teamSpaceName.length > 8) {
-    showToast('팀 이름은 최대 8자까지 가능해요');
+  } else if (teamSpaceName.length > 10) {
+    showToast('팀 이름은 최대 10자까지 가능해요');
     return false;
   }
   return true;


### PR DESCRIPTION
팀스페이스와 관련된 디버깅 진행했습니다.
- 팀 이름을 최대 10글자까지로 제한
- 팀 스페이스 삭제 / 팀 탈퇴 시 라우팅 꼬이지 않게 수정
   - 기존에는 navigate('/teamspace/list')로 히스토리 스택을 추가해서, 뒤로가기 하면 작업 수행 이전의 화면이 나왔음
   - 현재는 navigate(-2) 또는 navigate(-1)로 히스토리 스택을 추가하지 않고 이전 화면으로 이동 시킴
- 종료된 팀스페이스는 수정을 못하고, 팀 공유링크 버튼 대신 시작일~종료일로 대체

<img width="430" alt="스크린샷 2025-02-20 오후 9 49 41" src="https://github.com/user-attachments/assets/1b90d63d-a704-4426-8abf-a9cdec5b18b5" />

<img width="396" alt="스크린샷 2025-02-20 오후 9 35 59" src="https://github.com/user-attachments/assets/24cdd1a7-75ff-4237-a160-c23e5942e52a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Adjusted navigation flow after leaving a team, ensuring a more intuitive redirection.
  - Enhanced team management views by passing status context and conditionally displaying invitation options or formatted dates.
  - Added team name validation with an 8-character limit that provides immediate feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->