### PR TITLE
[FD-404] 주관식 피드백 없이 피드백을 보낼 수 없는 버그 수정

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/dto/request/FrequentFeedbackSendRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/dto/request/FrequentFeedbackSendRequest.java
@@ -5,7 +5,6 @@ import com.feedhanjum.back_end.feedback.domain.Feedback;
 import com.feedhanjum.back_end.feedback.domain.FeedbackFeeling;
 import com.feedhanjum.back_end.feedback.domain.ObjectiveFeedback;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -29,7 +28,6 @@ public record FrequentFeedbackSendRequest(
         List<ObjectiveFeedback> objectiveFeedbacks,
 
         @Schema(description = "주관식 피드백")
-        @NotBlank
         @ByteLength(min = Feedback.MIN_SUBJECTIVE_FEEDBACK_BYTE, max = Feedback.MAX_SUBJECTIVE_FEEDBACK_BYTE, strip = true)
         String subjectiveFeedback,
 

--- a/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/dto/request/RegularFeedbackSendRequest.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/feedback/controller/dto/request/RegularFeedbackSendRequest.java
@@ -5,7 +5,6 @@ import com.feedhanjum.back_end.feedback.domain.Feedback;
 import com.feedhanjum.back_end.feedback.domain.FeedbackFeeling;
 import com.feedhanjum.back_end.feedback.domain.ObjectiveFeedback;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -30,7 +29,6 @@ public record RegularFeedbackSendRequest(
         List<ObjectiveFeedback> objectiveFeedbacks,
 
         @Schema(description = "주관식 피드백")
-        @NotBlank
         @ByteLength(min = Feedback.MIN_SUBJECTIVE_FEEDBACK_BYTE, max = Feedback.MAX_SUBJECTIVE_FEEDBACK_BYTE, strip = true)
         String subjectiveFeedback,
 


### PR DESCRIPTION
# 관련 이슈
FD-404

# 변경된 점
- 정기, 수시 피드백을 보내는 API에서 주관식 피드백이 비어있어도 유효하도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Feedback submissions now offer more flexibility: users can leave the additional comments section empty if desired, while any provided text still adheres to length restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->