### PR TITLE
[FD-406] 동일 팀으로 두번 연속 변경시 내용 사라지는 버그 수정

### DIFF
--- a/front-end/src/pages/feedback/FeedbackHistory.jsx
+++ b/front-end/src/pages/feedback/FeedbackHistory.jsx
@@ -126,8 +126,10 @@ export default function FeedbackHistory() {
           <DropdownSmall
             triggerText={selectedTeam}
             setTriggerText={(text) => {
-              setSelectedTeam(text);
-              refreshData();
+              if (text !== selectedTeam) {
+                setSelectedTeam(text);
+                refreshData();
+              }
             }}
             items={teams.map((team) => team.name)}
           />


### PR DESCRIPTION
피드백 보관함, 회고 보관함에서 팀 선택 드롭다운 동일 팀 두번 연속 선택시 사라지는 버그 수정했습니다.
- 드롭다운 선택시 이전 항목과 비교해서 달라졌을때만 작업 수행하도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the Feedback History page by updating data only when a new selection is made. This improvement prevents unnecessary refreshes and provides a smoother, more responsive experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->