### PR TITLE
[FD-403] 일정 디버깅

### DIFF
--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -87,7 +87,7 @@ export default function Calendar() {
                   <ScheduleCard
                     schedule={schedule}
                     todos={schedule.scheduleMemberNestedDtoList}
-                    isFinished={checkIsFinished(schedule.endTime)}
+                    isFinished={checkIsFinished(schedule.endTime, new Date())}
                     onClickEdit={() => {
                       setSelectedSchedule(schedule);
                       setActionType(ScheduleActionType.EDIT);

--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -6,7 +6,7 @@ import ScheduleCard from './components/ScheduleCard';
 import StickyWrapper from '../../components/wrappers/StickyWrapper';
 import LargeButton from '../../components/buttons/LargeButton';
 import Icon from '../../components/Icon';
-import { checkIsFinished } from '../../utility/time';
+import { checkIsFinished, toKST } from '../../utility/time';
 import { ScheduleActionType } from './components/ScheduleAction';
 import ScheduleAction from './components/ScheduleAction';
 import { useLocation } from 'react-router-dom';
@@ -97,23 +97,25 @@ export default function Calendar() {
                 </li>
               );
             })}
-          <li className='mb-5'>
-            <LargeButton
-              text={
-                <p className='button-1 flex items-center gap-2 text-gray-300'>
-                  <Icon name='plusS' />
-                  새로운 일정 추가
-                </p>
-              }
-              onClick={() => {
-                clearData();
-                setActionType(ScheduleActionType.ADD);
-                setDoingAction(true);
-              }}
-              isOutlined={true}
-              disabled={true}
-            />
-          </li>
+          {checkIsFinished(toKST(selectedDate)) || (
+            <li className='mb-5'>
+              <LargeButton
+                text={
+                  <p className='button-1 flex items-center gap-2 text-gray-300'>
+                    <Icon name='plusS' />
+                    새로운 일정 추가
+                  </p>
+                }
+                onClick={() => {
+                  clearData();
+                  setActionType(ScheduleActionType.ADD);
+                  setDoingAction(true);
+                }}
+                isOutlined={true}
+                disabled={true}
+              />
+            </li>
+          )}
         </ul>
       </div>
       {scheduleOnDate && (

--- a/front-end/src/pages/calendar/components/ScheduleCard.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleCard.jsx
@@ -55,15 +55,19 @@ export default function ScheduleCard({
             <p className='subtitle-2 text-gray-100'>{schedule.scheduleName}</p>
           </div>
         </div>
-        {/* 일정 종료 전에만 수정 버튼 표시 */}
-        {!isFinished && (
-          <button onClick={() => onClickEdit()}>
-            <Icon
-              name='edit'
-              className={classNames('h-max w-max', schedule.teamName && 'pt-1')}
-            />
-          </button>
-        )}
+        {/* 일정 종료 전이고, 사용자가 팀 리더 또는 일정 생성자인 경우에만 수정 버튼 표시 */}
+        {!isFinished &&
+          (schedule.leaderId === userId || schedule.ownerId === userId) && (
+            <button onClick={() => onClickEdit()}>
+              <Icon
+                name='edit'
+                className={classNames(
+                  'h-max w-max',
+                  schedule.teamName && 'pt-1',
+                )}
+              />
+            </button>
+          )}
       </div>
       <hr className='w-full border-gray-500' />
       {/* 나의 역할 */}

--- a/front-end/src/pages/calendar/components/ScheduleCard.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleCard.jsx
@@ -42,7 +42,7 @@ export default function ScheduleCard({
         schedule.teamName ? 'p-4' : 'px-4 py-5',
       )}
     >
-      <div className='flex'>
+      <div className='flex items-start'>
         <div className='flex flex-1 flex-col gap-3'>
           {schedule.teamName && (
             <Tag type={TagType.TEAM_NAME}>{schedule.teamName}</Tag>
@@ -55,19 +55,15 @@ export default function ScheduleCard({
             <p className='subtitle-2 text-gray-100'>{schedule.scheduleName}</p>
           </div>
         </div>
-        {/* 일정 종료 전이고, 사용자가 팀 리더 또는 일정 생성자인 경우에만 수정 버튼 표시 */}
-        {!isFinished &&
-          (schedule.leaderId === userId || schedule.ownerId === userId) && (
-            <button onClick={() => onClickEdit()}>
-              <Icon
-                name='edit'
-                className={classNames(
-                  'h-max w-max',
-                  schedule.teamName && 'pt-1',
-                )}
-              />
-            </button>
-          )}
+        {/* 일정 종료 전에만 수정 버튼 표시 */}
+        {!isFinished && (
+          <button onClick={() => onClickEdit()}>
+            <Icon
+              name='edit'
+              className={classNames('h-max w-max', schedule.teamName && 'pt-1')}
+            />
+          </button>
+        )}
       </div>
       <hr className='w-full border-gray-500' />
       {/* 나의 역할 */}

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -56,7 +56,9 @@ export default function MainPage() {
   const { data: matesData } = useMainCard2(selectedTeam);
   const { data: notificationsData, markAsRead } = useNotification(selectedTeam);
 
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState(
+    new Date(new Date().setSeconds(0, 0)),
+  );
 
   const { actionInfo, clearData } = useScheduleAction(
     selectedDate,

--- a/front-end/src/utility/time.js
+++ b/front-end/src/utility/time.js
@@ -121,8 +121,8 @@ export function timeInPeriod(stdDate, startDate, endDate) {
  * @param {Date} date - 일정 종료 날짜
  * @returns {boolean} - 일정이 종료되었는지 여부
  */
-export function checkIsFinished(date) {
-  if (new Date(date) < new Date(toYMD(new Date()))) {
+export function checkIsFinished(date, stdDate = new Date(toYMD(new Date()))) {
+  if (new Date(date) < stdDate) {
     return true;
   } else {
     return false;

--- a/front-end/src/utility/time.js
+++ b/front-end/src/utility/time.js
@@ -119,6 +119,7 @@ export function timeInPeriod(stdDate, startDate, endDate) {
 /**
  * 현 시간 기준 일정이 종료되었는지 확인하는 함수
  * @param {Date} date - 일정 종료 날짜
+ * @param {Data} stdDate - 기준 날짜
  * @returns {boolean} - 일정이 종료되었는지 여부
  */
 export function checkIsFinished(date, stdDate = new Date(toYMD(new Date()))) {


### PR DESCRIPTION
일정과 관련된 각종 버그 디버깅했습니다.
- 메인페이지에서 일정 추가 10분 단위 에러 해결
- 일정 수정시 리더나 일정 생성자만 수정 가능하도록 허용
- 오늘 이전날짜에서는 일정 추가 버튼 삭제
- 일정 끝났는지 확인하는 함수 수정을 통해 정확히 계산

<h2> 수정 가능 인원 디버깅 </h2>
<img width="430" alt="스크린샷 2025-02-21 오후 11 44 44" src="https://github.com/user-attachments/assets/c78e2f60-cc11-494b-9858-5b7ae783685d" />
<img width="430" alt="스크린샷 2025-02-21 오후 11 44 49" src="https://github.com/user-attachments/assets/ef6cc367-4e95-4cf1-9c2a-474acc15081e" />

<h2> 오늘 이전날짜 일정 추가 불가 </h2>
<img width="430" alt="스크린샷 2025-02-21 오후 11 45 01" src="https://github.com/user-attachments/assets/257bc258-1afb-4962-8c32-3467aad94f7d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The calendar now only shows the add schedule button when scheduling is allowed, ensuring a clearer process.
  - Schedule management now restricts editing and deletion to authorized users, with helpful notifications for unauthorized attempts.
  - Date selection has been refined to display time rounded to the nearest minute for improved precision.

- **Style**
  - Adjusted schedule display for improved alignment and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->