### PR TITLE
[FD-411] 일정 validation 디버깅

### DIFF
--- a/front-end/src/pages/calendar/Calendar.jsx
+++ b/front-end/src/pages/calendar/Calendar.jsx
@@ -97,7 +97,7 @@ export default function Calendar() {
                 </li>
               );
             })}
-          {checkIsFinished(toKST(selectedDate)) || (
+          {!checkIsFinished(toKST(selectedDate)) && !showAllSchedule && (
             <li className='mb-5'>
               <LargeButton
                 text={

--- a/front-end/src/pages/calendar/components/ScheduleAction.jsx
+++ b/front-end/src/pages/calendar/components/ScheduleAction.jsx
@@ -11,7 +11,11 @@ import CustomInput from '../../../components/CustomInput';
 import LargeButton from '../../../components/buttons/LargeButton';
 import StickyWrapper from '../../../components/wrappers/StickyWrapper';
 import { showToast } from '../../../utility/handleToast';
-import { checkNewSchedule, isEmpty } from '../../../utility/inputChecker';
+import {
+  checkLength,
+  checkNewSchedule,
+  isEmpty,
+} from '../../../utility/inputChecker';
 import TimeSelector from './TimeSelector';
 import Todo from './Todo';
 import { hideModal, showModal } from '../../../utility/handleModal';
@@ -57,6 +61,7 @@ export default function ScheduleAction({
   setAllSchedules,
   setParentDate = () => {},
 }) {
+  const nameLengthLimit = 20;
   const { selectedTeam } = useTeam();
   const { userId } = useUser();
   const scrollRef = useRef(null);
@@ -222,7 +227,14 @@ export default function ScheduleAction({
       <CustomInput
         label='일정 이름'
         content={actionInfo?.scheduleName ?? ''}
-        setContent={canEdit ? actionInfo?.setScheduleName : null}
+        setContent={
+          canEdit ?
+            (text) => {
+              const newName = checkLength(text, nameLengthLimit);
+              actionInfo?.setScheduleName(newName);
+            }
+          : null
+        }
         isOutlined={false}
         bgColor='gray-700'
       />

--- a/front-end/src/pages/calendar/components/Todo.jsx
+++ b/front-end/src/pages/calendar/components/Todo.jsx
@@ -1,7 +1,9 @@
 import CustomInput from '../../../components/CustomInput';
 import Icon from '../../../components/Icon';
+import { checkLength } from '../../../utility/inputChecker';
 
 export default function Todo({ todos, setTodo, scrollRef }) {
+  const todoMaxLength = 50;
   return (
     <div className='flex flex-col gap-2'>
       <h3 className='subtitle-2 text-gray-0'>내 역할</h3>
@@ -12,10 +14,11 @@ export default function Todo({ todos, setTodo, scrollRef }) {
               <CustomInput
                 content={todo}
                 setContent={(value) => {
+                  const newValue = checkLength(value, todoMaxLength);
                   setTodo(
                     todos.map((todo, index2) => {
                       if (index2 === index) {
-                        return value;
+                        return newValue;
                       }
                       return todo;
                     }),

--- a/front-end/src/utility/inputChecker.js
+++ b/front-end/src/utility/inputChecker.js
@@ -221,3 +221,17 @@ export const checkResetPWInfos = (certState, password, passwordConfirm) => {
   }
   return true;
 };
+
+/**
+ * 역할 길이 검사
+ * @param {string} text
+ * @param {int} std
+ */
+export const checkLength = (text, std) => {
+  let result = text;
+  if (text.length > std) {
+    result = text.slice(0, std);
+    showToast(`최대 ${std}자까지 작성 가능해요`);
+  }
+  return result;
+};


### PR DESCRIPTION
일정 이름 최대 20자, 역할 최대 50자 제한 두었습니다.
전체 일정 보기 중에는 일정 추가가 불가능 하도록 버튼을 없앴습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the calendar view so that the action button now appears only when schedules are incomplete and a specific view option is disabled.
	- Enhanced input handling for schedule names and todo entries by enforcing character limits and providing real-time notifications when limits are exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->