### PR TITLE
[FD-422] 이메일 타입이 아닌 계정에 대한 비밀번호 초기화 방지 로직 추가

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/service/AuthService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/service/AuthService.java
@@ -114,7 +114,7 @@ public class AuthService {
     @Transactional(readOnly = true)
     public Optional<PasswordResetToken> sendPasswordResetEmail(String email) {
         Optional<MemberDetails> memberDetails = memberDetailsRepository.findByEmail(email);
-        if (memberDetails.isEmpty()) {
+        if (memberDetails.isEmpty() || !memberDetails.get().getAccountType().equals(MemberDetails.Type.EMAIL)) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
# 관련 이슈
FD-422

# 변경된 점
- 구글 계정이 비밀번호 초기화 메일 전송 시도 시 메일을 보내지 않도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the password reset process to ensure that only accounts registered with an email address can receive reset instructions, leading to a more secure and reliable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->