### PR TITLE
[FD-424] 팀 가입 API 응답으로 가입한 팀 정보 반환

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/controller/TeamController.java
@@ -174,12 +174,12 @@ public class TeamController {
 
     @Operation(summary = "팀 가입", description = "주어진 팀 가입 토큰을 이용해 팀에 가입한다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "팀 가입에 성공한 경우"),
-            @ApiResponse(responseCode = "404", description = "유효하지 않은 토큰으로 요청하거나, 만료된 경우")
+            @ApiResponse(responseCode = "200", description = "팀 가입에 성공한 경우"),
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 토큰으로 요청하거나, 만료된 경우", content = @Content),
     })
     @PostMapping("/join")
-    public ResponseEntity<Void> joinTeam(@Login Long memberId, @RequestParam String token) {
-        teamService.joinTeam(memberId, token);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<TeamResponse> joinTeam(@Login Long memberId, @RequestParam String token) {
+        Team team = teamService.joinTeam(memberId, token);
+        return ResponseEntity.ok(new TeamResponse(team));
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamJoinToken.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/TeamJoinToken.java
@@ -43,9 +43,11 @@ public class TeamJoinToken {
     }
 
     // 연관 팀에 가입
-    public void joinTeam(Member member) {
+    public Team joinTeam(Member member) {
         validate();
-        getTeam().join(member);
+        Team team = getTeam();
+        team.join(member);
+        return team;
     }
 
     public Team getTeamInfo() {

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/service/TeamService.java
@@ -135,13 +135,14 @@ public class TeamService {
     }
 
     @Transactional
-    public void joinTeam(Long memberId, String token) {
+    public Team joinTeam(Long memberId, String token) {
         TeamJoinToken teamJoinToken = teamJoinTokenRepository.findById(token)
                 .orElseThrow(() -> new EntityNotFoundException("토큰이 유효하지 않습니다."));
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
-        teamJoinToken.joinTeam(member);
+        Team team = teamJoinToken.joinTeam(member);
         eventPublisher.publishEvent(new TeamMemberJoinEvent(memberId, teamJoinToken.getTeamInfo().getId()));
+        return team;
     }
 
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerIntegrationTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/team/controller/TeamControllerIntegrationTest.java
@@ -660,7 +660,12 @@ public class TeamControllerIntegrationTest {
                             .uri("/api/team/join")
                             .queryParam("token", token.getToken())
                             .session(withLoginUser(notMember))
-            ).hasStatus(HttpStatus.NO_CONTENT);
+            ).hasStatus(HttpStatus.OK)
+                    .body()
+                    .satisfies(result -> {
+                        TeamResponse teamResponse = mapper.readValue(result, TeamResponse.class);
+                        assertThat(teamResponse.id()).isEqualTo(team.getId());
+                    });
 
             Team updatedTeam = teamRepository.findById(team.getId()).orElseThrow();
             assertThat(updatedTeam.isTeamMember(notMember)).isTrue();


### PR DESCRIPTION
# 관련 이슈
FD-424

# 변경된 점
- 팀 가입 API 응답으로 가입한 팀 정보 변환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The team join operation now returns detailed team information with a 200 OK response, providing clear confirmation on successful team membership.
- **Documentation**
	- API response descriptions have been updated to accurately reflect success and error scenarios.
- **Tests**
	- Enhanced tests now verify that the operation returns the expected team details and proper response status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->