### PR TITLE
[FD-425] 구글-로그인 api에 409 상태코드 추가

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/AuthController.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/controller/AuthController.java
@@ -197,7 +197,8 @@ public class AuthController {
     @Operation(summary = "구글 로그인 or 구글 회원가입 토큰 응답", description = "구글 회원가입된 상태라면 로그인, 아니라면 회원가입 시 필요한 토큰을 발급합니다")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 or 회원가입 토큰 발급 성공"),
-            @ApiResponse(responseCode = "401", description = "구글 로그인 실패", content = @Content)
+            @ApiResponse(responseCode = "401", description = "구글 로그인 실패", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 중복되는 이메일 계정이 존재하는 경우", content = @Content)
     })
     @PostMapping("/google/login")
     public ResponseEntity<GoogleLoginResponse> loginWithGoogle(HttpSession session, @Valid @RequestBody GoogleLoginRequest request) {

--- a/back-end/src/main/java/com/feedhanjum/back_end/auth/service/AuthService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/auth/service/AuthService.java
@@ -187,7 +187,9 @@ public class AuthService {
         }
 
         MemberDetails memberDetails = memberDetailsOptional.get();
-        memberDetails.validateGoogleAccount();
+        if (!memberDetails.getAccountType().equals(MemberDetails.Type.GOOGLE)) {
+            throw new EmailAlreadyExistsException("이메일로 회원가입한 계정이 이미 존재합니다.");
+        }
         return GoogleLoginResultDto.authenticated(memberDetails);
     }
 

--- a/back-end/src/test/java/com/feedhanjum/back_end/auth/service/AuthServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/auth/service/AuthServiceTest.java
@@ -206,7 +206,7 @@ class AuthServiceTest {
 
             // when & then
             assertThatThrownBy(() -> authService.authenticateGoogle(googleCode))
-                    .isInstanceOf(InvalidCredentialsException.class);
+                    .isInstanceOf(EmailAlreadyExistsException.class);
         }
 
         @Test


### PR DESCRIPTION
# 관련 이슈
FD-425

# 변경된 점
- 구글 로그인 시도 시 이미 동일한 메일로 가입된 이메일 계정이 존재한다면 409 반환