### PR TITLE
[FD-432] TeamPlanOrchestrationService 공유 잠금과 배타 잠금 구분해서 사용하도록 변경

### DIFF
--- a/back-end/src/main/java/com/feedhanjum/back_end/core/exception/InternalErrorControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/exception/InternalErrorControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.feedhanjum.back_end.core.exception;
 
 import jakarta.persistence.LockTimeoutException;
+import jakarta.persistence.OptimisticLockException;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.NonUniqueResultException;
 import org.springframework.core.annotation.Order;
@@ -28,6 +29,12 @@ public class InternalErrorControllerAdvice {
     @ExceptionHandler(LockTimeoutException.class)
     public ResponseEntity<String> handleLockTimeoutException(LockTimeoutException e) {
         log.error("Lock timeout exception occurred!", e);
+        return new ResponseEntity<>("Service Unavailable", HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @ExceptionHandler(OptimisticLockException.class)
+    public ResponseEntity<String> handleOptimisticLockException(OptimisticLockException e) {
+        log.error("Optimistic lock exception occurred!", e);
         return new ResponseEntity<>("Service Unavailable", HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/core/exception/InternalErrorControllerAdvice.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/core/exception/InternalErrorControllerAdvice.java
@@ -7,6 +7,7 @@ import org.hibernate.NonUniqueResultException;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -32,7 +33,7 @@ public class InternalErrorControllerAdvice {
         return new ResponseEntity<>("Service Unavailable", HttpStatus.SERVICE_UNAVAILABLE);
     }
 
-    @ExceptionHandler(OptimisticLockException.class)
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
     public ResponseEntity<String> handleOptimisticLockException(OptimisticLockException e) {
         log.error("Optimistic lock exception occurred!", e);
         return new ResponseEntity<>("Service Unavailable", HttpStatus.SERVICE_UNAVAILABLE);

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -37,9 +37,6 @@ public class Team {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Version
-    private int version;
-
     private String name;
 
     private LocalDate startDate;

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/domain/Team.java
@@ -37,6 +37,9 @@ public class Team {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private int version;
+
     private String name;
 
     private LocalDate startDate;

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
@@ -12,5 +12,10 @@ import java.util.Optional;
 public interface TeamRepository extends JpaRepository<Team, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select t from Team t where t.id = :id")
-    Optional<Team> findByIdForUpdate(@Param("id") Long id);
+    Optional<Team> findByIdForUpdateExclusiveLock(@Param("id") Long id);
+
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("select t from Team t where t.id = :id")
+    Optional<Team> findByIdForUpdateSharedLock(@Param("id") Long id);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
@@ -10,7 +10,13 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select t from Team t where t.id = :id")
-    Optional<Team> findByIdOptimisticLockForceIncrement(@Param("id") Long id);
+    Optional<Team> findByIdForUpdateExclusiveLock(@Param("id") Long id);
+
+
+    @Lock(LockModeType.PESSIMISTIC_READ)
+    @Query("select t from Team t where t.id = :id")
+    Optional<Team> findByIdForUpdateSharedLock(@Param("id") Long id);
+
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/team/repository/TeamRepository.java
@@ -10,12 +10,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
     @Query("select t from Team t where t.id = :id")
-    Optional<Team> findByIdForUpdateExclusiveLock(@Param("id") Long id);
-
-
-    @Lock(LockModeType.PESSIMISTIC_READ)
-    @Query("select t from Team t where t.id = :id")
-    Optional<Team> findByIdForUpdateSharedLock(@Param("id") Long id);
+    Optional<Team> findByIdOptimisticLockForceIncrement(@Param("id") Long id);
 }

--- a/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
@@ -47,7 +47,7 @@ public class TeamPlanOrchestrationService {
      */
     @Transactional
     public Team updateTeamInfo(Long leaderId, Long teamId, TeamUpdateDto teamUpdateDto) {
-        Team team = teamRepository.findByIdForUpdateExclusiveLock(teamId)
+        Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member leader = memberRepository.findById(leaderId)
                 .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
@@ -70,7 +70,7 @@ public class TeamPlanOrchestrationService {
      */
     @Transactional
     public void createSchedule(Long memberId, Long teamId, ScheduleRequestDto requestDto) {
-        Team team = teamRepository.findByIdForUpdateSharedLock(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+        Team team = teamRepository.findByIdOptimisticLockForceIncrement(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
         teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).orElseThrow(() -> new TeamMembershipNotFoundException("해당 팀에 존재하는 사람만 일정을 생성할 수 있습니다."));
         Schedule findSchedule = scheduleRepository.findByTeamIdAndStartTime(teamId, requestDto.startTime()).orElse(null);

--- a/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
@@ -47,7 +47,7 @@ public class TeamPlanOrchestrationService {
      */
     @Transactional
     public Team updateTeamInfo(Long leaderId, Long teamId, TeamUpdateDto teamUpdateDto) {
-        Team team = teamRepository.findById(teamId)
+        Team team = teamRepository.findByIdForUpdateExclusiveLock(teamId)
                 .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member leader = memberRepository.findById(leaderId)
                 .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
@@ -70,7 +70,7 @@ public class TeamPlanOrchestrationService {
      */
     @Transactional
     public void createSchedule(Long memberId, Long teamId, ScheduleRequestDto requestDto) {
-        Team team = teamRepository.findByIdOptimisticLockForceIncrement(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+        Team team = teamRepository.findByIdForUpdateSharedLock(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
         teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).orElseThrow(() -> new TeamMembershipNotFoundException("해당 팀에 존재하는 사람만 일정을 생성할 수 있습니다."));
         Schedule findSchedule = scheduleRepository.findByTeamIdAndStartTime(teamId, requestDto.startTime()).orElse(null);

--- a/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
+++ b/back-end/src/main/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationService.java
@@ -47,7 +47,7 @@ public class TeamPlanOrchestrationService {
      */
     @Transactional
     public Team updateTeamInfo(Long leaderId, Long teamId, TeamUpdateDto teamUpdateDto) {
-        Team team = teamRepository.findByIdForUpdate(teamId)
+        Team team = teamRepository.findByIdForUpdateExclusiveLock(teamId)
                 .orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member leader = memberRepository.findById(leaderId)
                 .orElseThrow(() -> new EntityNotFoundException("멤버를 찾을 수 없습니다"));
@@ -70,7 +70,7 @@ public class TeamPlanOrchestrationService {
      */
     @Transactional
     public void createSchedule(Long memberId, Long teamId, ScheduleRequestDto requestDto) {
-        Team team = teamRepository.findByIdForUpdate(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
+        Team team = teamRepository.findByIdForUpdateSharedLock(teamId).orElseThrow(() -> new EntityNotFoundException("팀을 찾을 수 없습니다."));
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("해당 사용자를 찾을 수 없습니다."));
         teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId).orElseThrow(() -> new TeamMembershipNotFoundException("해당 팀에 존재하는 사람만 일정을 생성할 수 있습니다."));
         Schedule findSchedule = scheduleRepository.findByTeamIdAndStartTime(teamId, requestDto.startTime()).orElse(null);

--- a/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
@@ -104,7 +104,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
 
             // when
@@ -129,7 +129,7 @@ class TeamPlanOrchestrationServiceTest {
             Team team = createTeamWithId("team", member);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
 
-            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
 
             // when, then
@@ -147,7 +147,7 @@ class TeamPlanOrchestrationServiceTest {
             LocalDate endDate = LocalDate.of(2025, 1, 2);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.ANONYMOUS);
 
-            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.empty());
+            when(teamRepository.findByIdForUpdateExclusiveLock(teamId)).thenReturn(Optional.empty());
 
             // when, then
             assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(memberId, teamId, teamUpdateDto))
@@ -168,7 +168,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("hoho", startDate, endDate, FeedbackType.ANONYMOUS);
 
             when(memberRepository.findById(notLeader.getId())).thenReturn(Optional.of(notLeader));
-            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
 
             // when, then
             assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(notLeader.getId(), team.getId(), teamUpdateDto))
@@ -188,7 +188,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
             when(scheduleQueryRepository.findLatestEndTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 4, 0, 10, 0)));
 
@@ -210,7 +210,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findByIdForUpdate(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
             when(scheduleQueryRepository.findEarliestStartTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 1, 0, 10, 0)));
 
@@ -241,7 +241,7 @@ class TeamPlanOrchestrationServiceTest {
             when(requestDto.todos()).thenReturn(List.of(hehe));
 
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             when(team.getStartDate()).thenReturn(LocalDate.of(2025, 2, 28));
             when(team.getEndDate()).thenReturn(LocalDate.of(2025, 3, 2));
 
@@ -287,7 +287,7 @@ class TeamPlanOrchestrationServiceTest {
             Long memberId = 1L;
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.empty());
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.empty());
 
             // when, then
             assertThatThrownBy(() ->
@@ -304,7 +304,7 @@ class TeamPlanOrchestrationServiceTest {
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
             // when, then
@@ -322,7 +322,7 @@ class TeamPlanOrchestrationServiceTest {
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
@@ -344,7 +344,7 @@ class TeamPlanOrchestrationServiceTest {
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             when(requestDto.startTime()).thenReturn(LocalDateTime.of(2025, 3, 1, 10, 0));
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdate(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))

--- a/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
@@ -104,7 +104,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
 
             // when
@@ -129,7 +129,7 @@ class TeamPlanOrchestrationServiceTest {
             Team team = createTeamWithId("team", member);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
 
-            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
 
             // when, then
@@ -147,7 +147,7 @@ class TeamPlanOrchestrationServiceTest {
             LocalDate endDate = LocalDate.of(2025, 1, 2);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.ANONYMOUS);
 
-            when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
+            when(teamRepository.findByIdForUpdateExclusiveLock(teamId)).thenReturn(Optional.empty());
 
             // when, then
             assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(memberId, teamId, teamUpdateDto))
@@ -168,7 +168,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("hoho", startDate, endDate, FeedbackType.ANONYMOUS);
 
             when(memberRepository.findById(notLeader.getId())).thenReturn(Optional.of(notLeader));
-            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
 
             // when, then
             assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(notLeader.getId(), team.getId(), teamUpdateDto))
@@ -188,7 +188,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
             when(scheduleQueryRepository.findLatestEndTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 4, 0, 10, 0)));
 
@@ -210,7 +210,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
             when(scheduleQueryRepository.findEarliestStartTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 1, 0, 10, 0)));
 
@@ -241,7 +241,7 @@ class TeamPlanOrchestrationServiceTest {
             when(requestDto.todos()).thenReturn(List.of(hehe));
 
             Team team = mock(Team.class);
-            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             when(team.getStartDate()).thenReturn(LocalDate.of(2025, 2, 28));
             when(team.getEndDate()).thenReturn(LocalDate.of(2025, 3, 2));
 
@@ -287,7 +287,7 @@ class TeamPlanOrchestrationServiceTest {
             Long memberId = 1L;
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.empty());
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.empty());
 
             // when, then
             assertThatThrownBy(() ->
@@ -304,7 +304,7 @@ class TeamPlanOrchestrationServiceTest {
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             Team team = mock(Team.class);
-            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
             // when, then
@@ -322,7 +322,7 @@ class TeamPlanOrchestrationServiceTest {
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             Team team = mock(Team.class);
-            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
@@ -344,7 +344,7 @@ class TeamPlanOrchestrationServiceTest {
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             when(requestDto.startTime()).thenReturn(LocalDateTime.of(2025, 3, 1, 10, 0));
             Team team = mock(Team.class);
-            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))

--- a/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
+++ b/back-end/src/test/java/com/feedhanjum/back_end/teamplanorchestration/service/TeamPlanOrchestrationServiceTest.java
@@ -104,7 +104,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
 
             // when
@@ -129,7 +129,7 @@ class TeamPlanOrchestrationServiceTest {
             Team team = createTeamWithId("team", member);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
 
-            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
 
             // when, then
@@ -147,7 +147,7 @@ class TeamPlanOrchestrationServiceTest {
             LocalDate endDate = LocalDate.of(2025, 1, 2);
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.ANONYMOUS);
 
-            when(teamRepository.findByIdForUpdateExclusiveLock(teamId)).thenReturn(Optional.empty());
+            when(teamRepository.findById(teamId)).thenReturn(Optional.empty());
 
             // when, then
             assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(memberId, teamId, teamUpdateDto))
@@ -168,7 +168,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("hoho", startDate, endDate, FeedbackType.ANONYMOUS);
 
             when(memberRepository.findById(notLeader.getId())).thenReturn(Optional.of(notLeader));
-            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
 
             // when, then
             assertThatThrownBy(() -> teamPlanOrchestrationService.updateTeamInfo(notLeader.getId(), team.getId(), teamUpdateDto))
@@ -188,7 +188,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
             when(scheduleQueryRepository.findLatestEndTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 4, 0, 10, 0)));
 
@@ -210,7 +210,7 @@ class TeamPlanOrchestrationServiceTest {
             TeamUpdateDto teamUpdateDto = new TeamUpdateDto("haha", startDate, endDate, FeedbackType.IDENTIFIED);
             Team team = createTeamWithId("team", leader, startDate, endDate, LocalDate.now(clock));
 
-            when(teamRepository.findByIdForUpdateExclusiveLock(team.getId())).thenReturn(Optional.of(team));
+            when(teamRepository.findById(team.getId())).thenReturn(Optional.of(team));
             when(memberRepository.findById(leader.getId())).thenReturn(Optional.of(leader));
             when(scheduleQueryRepository.findEarliestStartTimeByTeamId(team.getId())).thenReturn(Optional.of(LocalDateTime.of(2025, 1, 1, 0, 10, 0)));
 
@@ -241,7 +241,7 @@ class TeamPlanOrchestrationServiceTest {
             when(requestDto.todos()).thenReturn(List.of(hehe));
 
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
             when(team.getStartDate()).thenReturn(LocalDate.of(2025, 2, 28));
             when(team.getEndDate()).thenReturn(LocalDate.of(2025, 3, 2));
 
@@ -287,7 +287,7 @@ class TeamPlanOrchestrationServiceTest {
             Long memberId = 1L;
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
-            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.empty());
+            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.empty());
 
             // when, then
             assertThatThrownBy(() ->
@@ -304,7 +304,7 @@ class TeamPlanOrchestrationServiceTest {
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
             when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
             // when, then
@@ -322,7 +322,7 @@ class TeamPlanOrchestrationServiceTest {
             Long teamId = 1L;
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))
@@ -344,7 +344,7 @@ class TeamPlanOrchestrationServiceTest {
             ScheduleRequestDto requestDto = mock(ScheduleRequestDto.class);
             when(requestDto.startTime()).thenReturn(LocalDateTime.of(2025, 3, 1, 10, 0));
             Team team = mock(Team.class);
-            when(teamRepository.findByIdForUpdateSharedLock(teamId)).thenReturn(Optional.of(team));
+            when(teamRepository.findByIdOptimisticLockForceIncrement(teamId)).thenReturn(Optional.of(team));
             Member member = mock(Member.class);
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(teamMemberRepository.findByMemberIdAndTeamId(memberId, teamId))


### PR DESCRIPTION
# 관련 이슈
FD-432

# 변경된 점
- [x] createSchedule 에서 team에 공유 잠금 적용
- [x] updateTeamInfo 에서 team에 배타 잠금 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved error handling now reliably informs users when the service is temporarily unavailable due to data concurrency issues.
- **Refactor**
	- Updated internal locking strategies for team updates and schedule creation to enhance data consistency and support concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->