### PR TITLE
[FD-433] 프론트 버그 수정

### DIFF
--- a/front-end/src/api/useFeedback.js
+++ b/front-end/src/api/useFeedback.js
@@ -89,11 +89,15 @@ export const useEditFavorite = () => {
   });
 };
 
-export const useFeedbackFavoriteByUser = (data) => {
+export const useFeedbackFavoriteByUser = (userId) => {
+  if (userId == null) {
+    return { data: null };
+  }
+
   return useQuery({
     queryKey: ['feedback-favorite-by-user'],
     queryFn: () =>
-      api.get({ url: `/api/member/feedback-prefer?findMemberId=${data}` }),
+      api.get({ url: `/api/member/feedback-prefer?findMemberId=${userId}` }),
     gcTime: 0, // 지난번 거랑 바뀌는게 보기 좋지 않아서 그냥 캐싱 X
   });
 };

--- a/front-end/src/api/useTeamspace.js
+++ b/front-end/src/api/useTeamspace.js
@@ -68,7 +68,9 @@ export const useEditTeam = (teamId) => {
   });
 };
 
-export const useJoinTeam = () => {
+export const useJoinTeam = (teamCode) => {
+  if (!teamCode) return { mutation: null };
+
   const queryClient = useQueryClient();
   const { selectTeam } = useTeam();
   return useMutation({

--- a/front-end/src/pages/auth/Splash.jsx
+++ b/front-end/src/pages/auth/Splash.jsx
@@ -19,7 +19,7 @@ export default function Splash() {
   const navigate = useNavigate();
   const { userId, setUserId } = useUser();
   const { data: member } = useGetMember(userId);
-  const { mutate: joinTeam } = useJoinTeam();
+  const { mutate: joinTeam } = useJoinTeam(teamCode);
   const { data: googleAuthUrl } = useGetGoogleUrl();
 
   /**
@@ -34,7 +34,7 @@ export default function Splash() {
     setTimeout(() => {
       if (member) {
         setUserId(member.id);
-        if (teamCode) {
+        if (teamCode && joinTeam) {
           joinTeam(teamCode);
         }
         moveTo('/main');

--- a/front-end/src/pages/feedback/FeedbackFavorite.jsx
+++ b/front-end/src/pages/feedback/FeedbackFavorite.jsx
@@ -24,8 +24,7 @@ export default function FeedbackFavorite() {
   const [selectedContent, setSelectedContent] = useState([]);
 
   const { data: keywords } = useFeedbackFavorite();
-  const { data: selectedKeywords } =
-    userId ? useFeedbackFavoriteByUser(userId) : { data: null };
+  const { data: selectedKeywords } = useFeedbackFavoriteByUser(userId);
 
   const mutation =
     process === 'signup' ?

--- a/front-end/src/pages/main/MainPage.jsx
+++ b/front-end/src/pages/main/MainPage.jsx
@@ -131,7 +131,7 @@ export default function MainPage() {
   }, [teams]);
 
   const getOnMainButtonClick = () => {
-    if (teams.length === 0) {
+    if (filteredTeams?.length === 0) {
       return () => navigate('/teamspace/make');
     }
     if (!recentScheduleData) {


### PR DESCRIPTION
- 로그아웃 시 스플래시에서 setTeam을 호출해서 localStroage가 덮어쓰여지는 문제 해결
- 회원가입시 선호 키워드 관련 커스텀 훅에 발생한 문제 해결
- 메인에서 팀 리스트 잘못참조 (filteredTeams가 아닌 일반 teams를 참조)하는 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved feedback retrieval by returning a proper fallback when no valid user identifier is provided.
	- Enhanced team join functionality by requiring a valid team code before proceeding.
	- Updated the team joining flow on the splash page and refined main page navigation to ensure more accurate routing based on available team data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->