### PR TITLE
[FD-435] 마지막 세가지 수정

### DIFF
--- a/front-end/src/components/TeamMatesCard.jsx
+++ b/front-end/src/components/TeamMatesCard.jsx
@@ -59,7 +59,7 @@ export default function TeamMatesCard({
         )}
       </div>
       <MediumButton
-        text='피드백 보관함'
+        text='받은 피드백 보관함'
         onClick={onReceivedFeedbackClick}
         disabled={true}
       />

--- a/front-end/src/components/buttons/MediumButton.jsx
+++ b/front-end/src/components/buttons/MediumButton.jsx
@@ -19,7 +19,7 @@ export default function MediumButton({
     <button
       // disabled={disabled}
       className={classNames(
-        'button-1 rounded-300 flex h-[46px] w-full items-center justify-center px-4 py-2 text-gray-300',
+        'button-1 rounded-300 flex h-[46px] w-full items-center justify-center px-4 py-2 text-gray-300 outline-none',
         isOutlined ?
           disabled ? 'border border-gray-500 bg-gray-800 text-gray-300'
           : 'cursor-pointer border border-lime-500 text-lime-500'

--- a/front-end/src/pages/main/components/Banner.jsx
+++ b/front-end/src/pages/main/components/Banner.jsx
@@ -62,6 +62,7 @@ export default function Banner({ banner, onClose }) {
             handleFreqFeedbackReq(navigate, {
               teamId: notification.teamId,
               senderId: ids.length > 1 ? null : notification.senderId,
+              senderName: ids.length > 1 ? null : notification.senderName,
             }),
           needColorfulWave: true,
         };


### PR DESCRIPTION
## 세가지 수정했습니다.
1. `피드백 보관함` 버튼을 `받은 피드백 보관함`으로 텍스트 변경
2. 모달에서 `MediumButton` 컴포넌트에 outline 생기는 문제 있어서 outline-none 적용
3. 배너 undefined 문제 해결 (보충 누군가 피드백 요청했을 때, 배너 통해서 피드백 안보내고 그냥 프로필 눌러서 보낸 경우, 배너의 피드백 보내기 누르면 undefined로 이름이 떴었는데,, 그냥 이름을 안던져주었기 때문 ^^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the feedback archive button label to "받은 피드백 보관함" for clearer user guidance.
  - Enhanced the feedback submission process by including sender information for improved context.
- **Style**
  - Refined button appearance by removing the focus outline for a cleaner visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->